### PR TITLE
Fix member display fields broken by Bootstrap 5 upgrade

### DIFF
--- a/netBS/core/CoreBundle/Resources/public/lib/xeditable/js/xeditable.bs4.js
+++ b/netBS/core/CoreBundle/Resources/public/lib/xeditable/js/xeditable.bs4.js
@@ -4773,20 +4773,35 @@ Editableform based on Twitter Bootstrap 3
 (function ($) {
     "use strict";
 
+    // Resolve popover defaults, compatible with Bootstrap 4 and 5.
+    // In BS5, $.fn.popover may only be registered after DOMContentLoaded,
+    // so we provide a safe fallback to avoid breaking script execution.
+    var popoverDefaults = null;
+    try {
+        if ($.fn.popover && $.fn.popover.Constructor) {
+            popoverDefaults = $.fn.popover.Constructor.DEFAULTS || $.fn.popover.Constructor.Default;
+        }
+    } catch(e) {}
+
     //extend methods
     $.extend($.fn.editableContainer.Popup.prototype, {
         containerName: 'popover',
         containerDataName: 'bs.popover',
         innerCss: '.popover-body',
-        defaults: $.fn.popover.Constructor.DEFAULTS,
+        defaults: popoverDefaults,
 
         initContainer: function(){
+
+            // Lazy-resolve popover defaults for BS5 (registered after DOMContentLoaded)
+            if (!this.defaults && $.fn.popover && $.fn.popover.Constructor) {
+                this.defaults = $.fn.popover.Constructor.DEFAULTS || $.fn.popover.Constructor.Default;
+            }
 
             $.extend(this.containerOptions, {
                 trigger: 'manual',
                 placement: 'auto',
                 content: ' ',
-                template: this.defaults.template
+                template: this.defaults ? this.defaults.template : undefined
             });
 
             //as template property is used in inputs, hide it from popover

--- a/netBS/core/CoreBundle/Resources/views/form/xeditable.theme.twig
+++ b/netBS/core/CoreBundle/Resources/views/form/xeditable.theme.twig
@@ -44,9 +44,9 @@
 
     {% elseif type in DATES %}
 
-        {{ registerJs(asset('bundles/netbscore/js/xeditable_hochet_datepicker.js')) }}
         {{ registerCss(asset('bundles/netbscore/lib/datetimepicker/bootstrap-datetimepicker.min.css')) }}
         {{ registerJs(asset('bundles/netbscore/lib/datetimepicker/bootstrap-datetimepicker.min.js')) }}
+        {{ registerJs(asset('bundles/netbscore/js/xeditable_hochet_datepicker.js')) }}
 
         data-type="hochetdatepicker"
         data-format="dd.mm.yyyy"


### PR DESCRIPTION
## Summary

- Fix missing Date de naissance, Date d'inscription, Date de désinscription, and Statut fields on the member display page
- Root cause: the BS4→BS5 upgrade (PR #9) broke the xeditable library's popover initialization, which cascaded into preventing date fields and all subsequent fields from rendering
- Patch `xeditable.bs4.js` popover IIFE to safely handle BS5's deferred `$.fn.popover` registration
- Fix JS load order in `xeditable.theme.twig` so `bootstrap-datetimepicker` loads before `xeditable_hochet_datepicker` (which depends on it)

## Root cause analysis

The Bootstrap 4 → 5.3.8 upgrade introduced a subtle breaking change in how jQuery plugins are registered. In BS4, `$.fn.popover` is available immediately when the script loads. In BS5, it's deferred until `DOMContentLoaded`.

The xeditable BS4 library (`xeditable.bs4.js`) accesses `$.fn.popover.Constructor.DEFAULTS` at script load time (line 4781), which throws a `TypeError` in BS5. Since the bundled datepicker is defined **later in the same file** (line 4857), the error halts script execution and the datepicker never registers.

This triggers a cascade:
1. `$.fn.datepicker` is never defined → `xeditable_hochet_datepicker.js` fails → `hochetdatepicker` type is never registered
2. xeditable hits the first date field → `$.error('Unknown type: hochetdatepicker')` throws inside jQuery's `.each()` loop
3. **All subsequent fields stop initializing** — including Statut (a working `select` type that simply comes after the date fields in DOM order)

## Test plan

- [ ] Open any member page (e.g. `/membre/page/{id}`) and verify all fields display their values: prénom, sexe, Numéro BS, Numéro AVS, **Date de naissance**, **Date d'inscription**, **Date de désinscription** (if ROLE_SG), **Statut**
- [ ] Click on a date field to verify inline editing still opens correctly
- [ ] Click on the Statut field to verify the select dropdown works
- [ ] Check the browser console for JavaScript errors on the member page

https://claude.ai/code/session_019jTB8WXRCwobrVKdnAx1ig