### PR TITLE
fix(membre): nouveau membre form + unify failed-submit handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ docs
 ###< symfonycasts/sass-bundle ###
 
 .superpowers/
+
+# Local working notes / TODO drafts (not committed)
+TODO.local.md
+*.todo.local.md

--- a/assets/lib/form_validation.js
+++ b/assets/lib/form_validation.js
@@ -7,13 +7,23 @@ export function validateForm(form) {
     let first = null;
     for (const el of form.elements) {
         if (!el.willValidate || el.checkValidity()) continue;
+        // A required <select> with zero selectable options can never be made valid
+        // by the user. Let it through so the server can render a meaningful error
+        // instead of silently blocking the submit.
+        if (el.tagName === 'SELECT' && !el.multiple && !hasSelectableOption(el)) continue;
         if (!first) first = el;
         markInvalid(el);
     }
 
+    if (!first) return true;
+
     first.focus({ preventScroll: true });
     first.scrollIntoView({ block: 'center', behavior: 'smooth' });
     return false;
+}
+
+function hasSelectableOption(select) {
+    return Array.from(select.options).some((opt) => opt.value !== '');
 }
 
 function clearValidationErrors(form) {
@@ -100,4 +110,8 @@ export function initGlobalFormValidation() {
             e.stopPropagation();
         }
     }, true);
+
+    // Server-side validation errors are surfaced via HTTP 422 responses, set
+    // globally by App\EventListener\InvalidFormStatusListener. Turbo natively
+    // re-renders 4xx responses, so no client-side body-swap is needed.
 }

--- a/assets/styles/plugin/_select2.scss
+++ b/assets/styles/plugin/_select2.scss
@@ -1,5 +1,37 @@
 $select2-border-width: 1px;
 
+// Server-side validation marks the underlying <select> with .is-invalid via the
+// Twig form theme. Our select2 widgets wrap that <select> in a styled div, so the
+// :has() selector propagates the red ring to the visible wrapper. Targets every
+// variant (static-search, multi, AJAX single/multi, plus the legacy jQuery select2
+// container that some pages still render).
+[data-controller="select2"]:has(> select.is-invalid),
+[data-controller~="select2"]:has(.select2-multi-control + select.is-invalid),
+.select2-search-wrapper:has(> select.is-invalid),
+.select2-ajax-wrapper:has(~ select.is-invalid),
+.select2-ajax-multi-wrapper:has(~ select.is-invalid) {
+  .form-control,
+  .select2-multi-control,
+  > select,
+  > input.form-control,
+  .select2-selection {
+    border-color: var(--bs-form-invalid-border-color, #dc3545) !important;
+  }
+}
+
+// Bootstrap's .invalid-feedback only displays when its previous sibling carries
+// .is-invalid. Custom widgets wrap the invalid <select> inside a div, breaking
+// that sibling relationship — force-display the feedback in those cases.
+[data-controller="select2"]:has(select.is-invalid) + .invalid-feedback,
+.select2-search-wrapper:has(select.is-invalid) + .invalid-feedback,
+.select2-ajax-wrapper:has(select.is-invalid) + .invalid-feedback,
+.select2-ajax-multi-wrapper:has(select.is-invalid) + .invalid-feedback,
+.input-daterange:has(.is-invalid) ~ .invalid-feedback,
+[data-controller="quill"]:has(.is-invalid) + .invalid-feedback {
+  display: block;
+}
+
+
 // Custom multi-select widget built by assets/controllers/select2_controller.js.
 // The outer .form-control is a div (not an <input>), so we mirror the focus
 // ring via :focus-within when the inner search input is focused.
@@ -24,6 +56,21 @@ $select2-border-width: 1px;
 
   .select2-tag {
     font-weight: 400;
+  }
+}
+
+// Static single-select with an inline search filter (built by _wrapWithSearch).
+// Stacks the search input above the native <select> with consistent spacing.
+.select2-search-wrapper {
+  display: block;
+  width: 100%;
+
+  > input.form-control {
+    margin-bottom: 0.25rem;
+  }
+
+  > select {
+    width: 100%;
   }
 }
 

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -142,6 +142,13 @@ services:
     tags:
       - { name: doctrine.event_listener, event: postLoad }
 
+  # Bumps a 200 form re-render to 422 so Turbo natively swaps the page.
+  # Paired with App\Form\Extension\InvalidFormStatusExtension which marks
+  # the request when any root form was submitted-and-invalid.
+  App\EventListener\InvalidFormStatusListener:
+    tags:
+      - { name: kernel.event_listener, event: kernel.response, priority: -10 }
+
   App\Service\NextcloudApiCall:
     arguments:
       $ncUrl: "%env(NEXTCLOUD_BASE_URI)%"

--- a/netBS/core/CoreBundle/Controller/Trait/HandlesFormPersistenceTrait.php
+++ b/netBS/core/CoreBundle/Controller/Trait/HandlesFormPersistenceTrait.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\CoreBundle\Controller\Trait;
+
+use Doctrine\DBAL\Exception\ConstraintViolationException;
+use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
+use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
+use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Form\FormError;
+use Symfony\Component\Form\FormInterface;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * Wraps `$em->flush()` to convert known Doctrine constraint violations into
+ * form-level errors. The caller then re-renders the form with `$form->createView()`
+ * and the user sees their input preserved + a French error message at the top.
+ *
+ * Use this in any controller that persists user-submitted data when the input
+ * could realistically collide with a UNIQUE / NOT NULL / FK constraint. The
+ * trait does not catch unrelated exceptions — those continue to surface
+ * normally so genuine bugs are visible.
+ *
+ * Example:
+ *
+ *     if ($form->isSubmitted() && $form->isValid()) {
+ *         $em->persist($entity);
+ *         if ($this->flushOrAttachConstraintError($em, $form)) {
+ *             return $this->redirectToRoute('…');
+ *         }
+ *         // fall through to re-render the form below
+ *     }
+ *
+ *     return $this->render('…', ['form' => $form->createView()]);
+ */
+trait HandlesFormPersistenceTrait
+{
+    /**
+     * Flushes the entity manager. On a known constraint violation, attaches
+     * a French error message to the form and returns false. On any other
+     * exception, lets it propagate.
+     *
+     * @return bool true on success (caller should redirect), false when an
+     *              error was attached to the form (caller should re-render).
+     */
+    protected function flushOrAttachConstraintError(
+        EntityManagerInterface $em,
+        FormInterface $form,
+        ?Request $request = null
+    ): bool {
+        try {
+            $em->flush();
+            return true;
+        } catch (UniqueConstraintViolationException $e) {
+            $form->addError(new FormError(
+                'Une de ces valeurs existe déjà dans la base. ' .
+                'Vérifiez les champs qui doivent être uniques. (' . $e->getMessage() . ')'
+            ));
+        } catch (NotNullConstraintViolationException $e) {
+            $form->addError(new FormError(
+                "Un champ obligatoire n'a pas été renseigné. (" . $e->getMessage() . ')'
+            ));
+        } catch (ForeignKeyConstraintViolationException $e) {
+            $form->addError(new FormError(
+                "Une référence à une autre entité n'est plus valide. (" . $e->getMessage() . ')'
+            ));
+        } catch (ConstraintViolationException $e) {
+            $form->addError(new FormError(
+                "Contrainte de base de données. (" . $e->getMessage() . ')'
+            ));
+        }
+
+        // Tell the InvalidFormStatusListener to bump the response to 422 — the
+        // form now carries an error even though Symfony's validator already
+        // ran (and passed) and won't re-fire its POST_SUBMIT hook.
+        if ($request !== null) {
+            $request->attributes->set(
+                \App\Form\Extension\InvalidFormStatusExtension::REQUEST_ATTRIBUTE,
+                true
+            );
+        }
+
+        return false;
+    }
+}

--- a/netBS/core/CoreBundle/Controller/Trait/HandlesFormPersistenceTrait.php
+++ b/netBS/core/CoreBundle/Controller/Trait/HandlesFormPersistenceTrait.php
@@ -13,38 +13,8 @@ use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
-/**
- * Wraps `$em->flush()` to convert known Doctrine constraint violations into
- * form-level errors. The caller then re-renders the form with `$form->createView()`
- * and the user sees their input preserved + a French error message at the top.
- *
- * Use this in any controller that persists user-submitted data when the input
- * could realistically collide with a UNIQUE / NOT NULL / FK constraint. The
- * trait does not catch unrelated exceptions — those continue to surface
- * normally so genuine bugs are visible.
- *
- * Example:
- *
- *     if ($form->isSubmitted() && $form->isValid()) {
- *         $em->persist($entity);
- *         if ($this->flushOrAttachConstraintError($em, $form)) {
- *             return $this->redirectToRoute('…');
- *         }
- *         // fall through to re-render the form below
- *     }
- *
- *     return $this->render('…', ['form' => $form->createView()]);
- */
 trait HandlesFormPersistenceTrait
 {
-    /**
-     * Flushes the entity manager. On a known constraint violation, attaches
-     * a French error message to the form and returns false. On any other
-     * exception, lets it propagate.
-     *
-     * @return bool true on success (caller should redirect), false when an
-     *              error was attached to the form (caller should re-render).
-     */
     protected function flushOrAttachConstraintError(
         EntityManagerInterface $em,
         FormInterface $form,
@@ -72,9 +42,9 @@ trait HandlesFormPersistenceTrait
             ));
         }
 
-        // Tell the InvalidFormStatusListener to bump the response to 422 — the
-        // form now carries an error even though Symfony's validator already
-        // ran (and passed) and won't re-fire its POST_SUBMIT hook.
+        // Symfony's validator already ran and passed before flush() — its
+        // POST_SUBMIT hook (InvalidFormStatusExtension) won't re-fire, so we
+        // set the 422-trigger attribute by hand.
         if ($request !== null) {
             $request->attributes->set(
                 \App\Form\Extension\InvalidFormStatusExtension::REQUEST_ATTRIBUTE,

--- a/netBS/core/CoreBundle/Controller/Trait/HandlesFormPersistenceTrait.php
+++ b/netBS/core/CoreBundle/Controller/Trait/HandlesFormPersistenceTrait.php
@@ -9,12 +9,21 @@ use Doctrine\DBAL\Exception\ForeignKeyConstraintViolationException;
 use Doctrine\DBAL\Exception\NotNullConstraintViolationException;
 use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 use Doctrine\ORM\EntityManagerInterface;
+use NetBS\CoreBundle\Form\FormResponseAttributes;
 use Symfony\Component\Form\FormError;
 use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 
 trait HandlesFormPersistenceTrait
 {
+    /** @var array<class-string<ConstraintViolationException>, string> */
+    private const CONSTRAINT_MESSAGES = [
+        UniqueConstraintViolationException::class => 'Une de ces valeurs existe déjà dans la base. Vérifiez les champs qui doivent être uniques.',
+        NotNullConstraintViolationException::class => "Un champ obligatoire n'a pas été renseigné.",
+        ForeignKeyConstraintViolationException::class => "Une référence à une autre entité n'est plus valide.",
+        ConstraintViolationException::class => 'Contrainte de base de données.',
+    ];
+
     protected function flushOrAttachConstraintError(
         EntityManagerInterface $em,
         FormInterface $form,
@@ -23,33 +32,16 @@ trait HandlesFormPersistenceTrait
         try {
             $em->flush();
             return true;
-        } catch (UniqueConstraintViolationException $e) {
-            $form->addError(new FormError(
-                'Une de ces valeurs existe déjà dans la base. ' .
-                'Vérifiez les champs qui doivent être uniques. (' . $e->getMessage() . ')'
-            ));
-        } catch (NotNullConstraintViolationException $e) {
-            $form->addError(new FormError(
-                "Un champ obligatoire n'a pas été renseigné. (" . $e->getMessage() . ')'
-            ));
-        } catch (ForeignKeyConstraintViolationException $e) {
-            $form->addError(new FormError(
-                "Une référence à une autre entité n'est plus valide. (" . $e->getMessage() . ')'
-            ));
         } catch (ConstraintViolationException $e) {
-            $form->addError(new FormError(
-                "Contrainte de base de données. (" . $e->getMessage() . ')'
-            ));
+            $message = self::CONSTRAINT_MESSAGES[$e::class] ?? self::CONSTRAINT_MESSAGES[ConstraintViolationException::class];
+            $form->addError(new FormError($message . ' (' . $e->getMessage() . ')'));
         }
 
         // Symfony's validator already ran and passed before flush() — its
         // POST_SUBMIT hook (InvalidFormStatusExtension) won't re-fire, so we
         // set the 422-trigger attribute by hand.
         if ($request !== null) {
-            $request->attributes->set(
-                \App\Form\Extension\InvalidFormStatusExtension::REQUEST_ATTRIBUTE,
-                true
-            );
+            $request->attributes->set(FormResponseAttributes::ROOT_INVALID, true);
         }
 
         return false;

--- a/netBS/core/CoreBundle/EventListener/DatabaseExceptionListener.php
+++ b/netBS/core/CoreBundle/EventListener/DatabaseExceptionListener.php
@@ -8,20 +8,9 @@ use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Last-resort safety net for uncaught DB constraint violations (SQLSTATE 23xxx —
- * NOT NULL, UNIQUE, FK). Surfaces a friendly toast message and a 422 response
- * instead of a raw 500. Crucially: this listener NEVER redirects, so the
- * browser stays on the same URL and the user's form data is preserved in the
- * native history (back button restores fields).
- *
- * Controllers that handle a specific form's known constraint violations
- * (e.g. uniqueness conflicts on user-edited fields) should catch the
- * Doctrine\DBAL\Exception\* subclasses themselves and re-render the form
- * with a form-level error — this listener is for the violations no controller
- * was prepared for.
- *
- * See {@see \NetBS\CoreBundle\Controller\Trait\HandlesFormPersistenceTrait}
- * for the controller-side helper.
+ * Safety net for uncaught DB constraint violations (SQLSTATE 23xxx). Returns
+ * 422 — never redirects, so the browser keeps the user's form data in history.
+ * Controllers should prefer HandlesFormPersistenceTrait for forms they own.
  */
 class DatabaseExceptionListener
 {
@@ -40,10 +29,6 @@ class DatabaseExceptionListener
             return;
         }
 
-        // Flash a friendly toast for the next page render. We intentionally do
-        // NOT redirect — redirecting destroys the user's POST data and is
-        // useless given the response will be a 422 the browser will not
-        // navigate to a new URL for.
         $session = $this->requestStack->getSession();
         if (method_exists($session, 'getFlashBag')) {
             $session->getFlashBag()->add('error',
@@ -52,11 +37,7 @@ class DatabaseExceptionListener
             );
         }
 
-        // Re-throw a clean 422 — Turbo treats 422 as a form-rejection and
-        // re-renders the response body in place. The body is whatever
-        // Symfony's error renderer produces for the exception (with the
-        // flash visible). Controllers that want better UX should catch the
-        // exception themselves and re-render their form.
+        // 422 so Turbo re-renders the response body in place instead of navigating.
         $event->setResponse(new Response(
             $this->renderErrorBody($dbException->getMessage()),
             Response::HTTP_UNPROCESSABLE_ENTITY,

--- a/netBS/core/CoreBundle/EventListener/DatabaseExceptionListener.php
+++ b/netBS/core/CoreBundle/EventListener/DatabaseExceptionListener.php
@@ -3,15 +3,25 @@
 namespace NetBS\CoreBundle\EventListener;
 
 use Doctrine\DBAL\Exception\DriverException;
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ExceptionEvent;
 use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
- * Catches database constraint violations (NOT NULL, UNIQUE, FK) and
- * redirects back with a flash error instead of showing a 500 page.
+ * Last-resort safety net for uncaught DB constraint violations (SQLSTATE 23xxx —
+ * NOT NULL, UNIQUE, FK). Surfaces a friendly toast message and a 422 response
+ * instead of a raw 500. Crucially: this listener NEVER redirects, so the
+ * browser stays on the same URL and the user's form data is preserved in the
+ * native history (back button restores fields).
+ *
+ * Controllers that handle a specific form's known constraint violations
+ * (e.g. uniqueness conflicts on user-edited fields) should catch the
+ * Doctrine\DBAL\Exception\* subclasses themselves and re-render the form
+ * with a form-level error — this listener is for the violations no controller
+ * was prepared for.
+ *
+ * See {@see \NetBS\CoreBundle\Controller\Trait\HandlesFormPersistenceTrait}
+ * for the controller-side helper.
  */
 class DatabaseExceptionListener
 {
@@ -30,13 +40,27 @@ class DatabaseExceptionListener
             return;
         }
 
-        $this->requestStack->getSession()->getFlashBag()->add('error',
-            "Les données saisies ne sont pas valides. Veuillez vérifier que tous les champs obligatoires sont remplis."
-        );
+        // Flash a friendly toast for the next page render. We intentionally do
+        // NOT redirect — redirecting destroys the user's POST data and is
+        // useless given the response will be a 422 the browser will not
+        // navigate to a new URL for.
+        $session = $this->requestStack->getSession();
+        if (method_exists($session, 'getFlashBag')) {
+            $session->getFlashBag()->add('error',
+                "Une contrainte de base de données a empêché l'enregistrement. " .
+                "Si le problème persiste, contactez un administrateur."
+            );
+        }
 
-        $event->setResponse(new RedirectResponse(
-            $this->refererOrCurrentUrl($event->getRequest()),
-            Response::HTTP_SEE_OTHER
+        // Re-throw a clean 422 — Turbo treats 422 as a form-rejection and
+        // re-renders the response body in place. The body is whatever
+        // Symfony's error renderer produces for the exception (with the
+        // flash visible). Controllers that want better UX should catch the
+        // exception themselves and re-render their form.
+        $event->setResponse(new Response(
+            $this->renderErrorBody($dbException->getMessage()),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+            ['Content-Type' => 'text/html; charset=utf-8'],
         ));
     }
 
@@ -56,8 +80,21 @@ class DatabaseExceptionListener
         return $sqlState !== null && str_starts_with($sqlState, '23');
     }
 
-    private function refererOrCurrentUrl(Request $request): string
+    private function renderErrorBody(string $detail): string
     {
-        return $request->headers->get('referer') ?: $request->getUri();
+        $escaped = htmlspecialchars($detail, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        return <<<HTML
+            <!doctype html>
+            <html lang="fr">
+            <head><meta charset="utf-8"><title>Erreur de base de données</title></head>
+            <body>
+                <h1>Erreur de base de données</h1>
+                <p>Une contrainte de base de données a empêché l'enregistrement.
+                   Cliquez sur le bouton « précédent » de votre navigateur pour
+                   retrouver le formulaire et corriger les valeurs.</p>
+                <pre style="white-space:pre-wrap">{$escaped}</pre>
+            </body>
+            </html>
+            HTML;
     }
 }

--- a/netBS/core/CoreBundle/EventListener/DatabaseExceptionListener.php
+++ b/netBS/core/CoreBundle/EventListener/DatabaseExceptionListener.php
@@ -29,13 +29,10 @@ class DatabaseExceptionListener
             return;
         }
 
-        $session = $this->requestStack->getSession();
-        if (method_exists($session, 'getFlashBag')) {
-            $session->getFlashBag()->add('error',
-                "Une contrainte de base de données a empêché l'enregistrement. " .
-                "Si le problème persiste, contactez un administrateur."
-            );
-        }
+        $this->requestStack->getSession()->getFlashBag()->add('error',
+            "Une contrainte de base de données a empêché l'enregistrement. " .
+            "Si le problème persiste, contactez un administrateur."
+        );
 
         // 422 so Turbo re-renders the response body in place instead of navigating.
         $event->setResponse(new Response(

--- a/netBS/core/CoreBundle/Form/FormResponseAttributes.php
+++ b/netBS/core/CoreBundle/Form/FormResponseAttributes.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\CoreBundle\Form;
+
+final class FormResponseAttributes
+{
+    /**
+     * Request attribute flag set when a root form submit failed validation.
+     * The 422-bump kernel.response listener reads it; the form type extension
+     * and HandlesFormPersistenceTrait both write it.
+     */
+    public const ROOT_INVALID = '_form_root_invalid';
+
+    private function __construct() {}
+}

--- a/netBS/core/CoreBundle/Resources/views/form/base.theme.twig
+++ b/netBS/core/CoreBundle/Resources/views/form/base.theme.twig
@@ -19,6 +19,18 @@
     {% endif %}
 {%- endblock form_start %}
 
+{# Match the client-side validation styling from assets/lib/form_validation.js:
+   a single <div class="invalid-feedback d-block"> per error, with no badge.
+   Root-form errors are rendered by the form_start banner above, so suppress
+   them here to avoid double-display when a template also calls form_errors(form). #}
+{% block form_errors -%}
+    {%- if errors|length > 0 and form is not rootform -%}
+        {%- for error in errors -%}
+            <div class="invalid-feedback d-block">{{ error.message }}</div>
+        {%- endfor -%}
+    {%- endif -%}
+{%- endblock form_errors %}
+
 {%- block widget_attributes -%}
     {% set class = attr.class is defined ? attr.class ~ ' input-sm' : 'input-sm' %}
     {% set attr = attr|merge({class: class}) %}

--- a/netBS/core/CoreBundle/Resources/views/form/base.theme.twig
+++ b/netBS/core/CoreBundle/Resources/views/form/base.theme.twig
@@ -1,6 +1,24 @@
 
 {% use "bootstrap_4_layout.html.twig" %}
 
+{# Auto-render form-level errors right after the opening <form> tag so any
+   error attached to the form root (e.g. by a post-persist constraint handler)
+   is always visible. Per-field errors continue to render below their field
+   via the bootstrap theme's form_row. #}
+{% block form_start -%}
+    {{- parent() -}}
+    {% if form.vars.errors|length > 0 %}
+        <div class="alert alert-danger" role="alert">
+            <strong>Le formulaire contient des erreurs :</strong>
+            <ul class="mb-0">
+                {% for error in form.vars.errors %}
+                    <li>{{ error.message }}</li>
+                {% endfor %}
+            </ul>
+        </div>
+    {% endif %}
+{%- endblock form_start %}
+
 {%- block widget_attributes -%}
     {% set class = attr.class is defined ? attr.class ~ ' input-sm' : 'input-sm' %}
     {% set attr = attr|merge({class: class}) %}
@@ -45,13 +63,14 @@
 {# select 2 stuff #}
 {% block ajax_select2_document_widget %}
 
+    {# `form.vars.value` is the ID string after the view transformer ran (the
+       norm/view data on the *field* is the ID, not the entity). For multiple,
+       it's a comma-separated string like "1,2,3". For single, just "63". #}
     {% set dataCheck = [] %}
-    {% if form.vars.multiple %}
-        {% for item in form.vars.data %}
-            {% set dataCheck = dataCheck|merge([item.id]) %}
-        {% endfor %}
-    {% elseif form.vars.data %}
-        {% set dataCheck = [form.vars.data.id] %}
+    {% if form.vars.multiple and form.vars.value %}
+        {% set dataCheck = form.vars.value|split(',') %}
+    {% elseif form.vars.value is not empty %}
+        {% set dataCheck = [form.vars.value] %}
     {% endif %}
 
     <div data-controller="select2"

--- a/netBS/core/FichierBundle/Select2/GroupeProvider.php
+++ b/netBS/core/FichierBundle/Select2/GroupeProvider.php
@@ -37,8 +37,9 @@ class GroupeProvider implements Select2ProviderInterface
      */
     public function toString($item)
     {
-	$parent = $item->getParent() ? " [" . $item->getParent()->getNom() . "] " : "";
-        return $item->getNom() . $parent .  " (" . $item->getGroupeType()->getNom() . ")";
+        $parent = $item->getParent() ? " [" . $item->getParent()->getNom() . "]" : "";
+        $type = $item->getGroupeType() ? " (" . $item->getGroupeType()->getNom() . ")" : "";
+        return $item->getNom() . $parent . $type;
     }
 
 

--- a/src/Controller/MembreController.php
+++ b/src/Controller/MembreController.php
@@ -3,6 +3,7 @@
 namespace App\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
+use NetBS\CoreBundle\Controller\Trait\HandlesFormPersistenceTrait;
 use NetBS\FichierBundle\Mapping\BaseFamille;
 use App\Entity\BSUser;
 use App\Form\CirculaireMembreType;
@@ -17,6 +18,8 @@ use Symfony\Component\Serializer\SerializerInterface;
 
 class MembreController extends AbstractController
 {
+    use HandlesFormPersistenceTrait;
+
     /**
      * @param Request $request
      * @return Response
@@ -39,13 +42,16 @@ class MembreController extends AbstractController
 
         $options = ['validation_groups' => $selectedFamilyId ? ['default'] : ['default', 'noFamily']];
         $infos->numero      = $previousNumber + 1;
-        $form               = $this->createForm(CirculaireMembreType::class, $infos, $options);
-        $form->handleRequest($request);
-
+        // Resolve famille BEFORE handleRequest so the group sequence ('noFamily')
+        // sees the right state for validation. On the failure path we must NOT
+        // call generateFamille() — it mutates $infos->famille and would skip the
+        // 'noFamily' validation group on the next submit, hiding required-field errors.
         if(!empty($selectedFamilyId)) {
             $infos->famille = $em->find($config->getFamilleClass(), intval($selectedFamilyId));
         }
-        else $infos->generateFamille();
+
+        $form               = $this->createForm(CirculaireMembreType::class, $infos, $options);
+        $form->handleRequest($request);
 
         if($form->isSubmitted() && $form->isValid()) {
 
@@ -58,9 +64,14 @@ class MembreController extends AbstractController
             $famille->addMembre($membre);
 
             $em->persist($famille);
-            $em->flush();
 
-            return $this->redirect($this->generateUrl('netbs.fichier.membre.page_membre', array('id' => $membre->getId())));
+            // DB constraint violations (e.g. UNIQUE on the auto-generated
+            // BSUser.username) turn into a form-level error and the response
+            // becomes 422 — the form re-renders with input intact and the
+            // alert banner explains what went wrong.
+            if ($this->flushOrAttachConstraintError($em, $form, $request)) {
+                return $this->redirect($this->generateUrl('netbs.fichier.membre.page_membre', array('id' => $membre->getId())));
+            }
         }
 
         return $this->render('membre/nouveau.html.twig', array(

--- a/src/EventListener/InvalidFormStatusListener.php
+++ b/src/EventListener/InvalidFormStatusListener.php
@@ -4,24 +4,14 @@ declare(strict_types=1);
 
 namespace App\EventListener;
 
-use App\Form\Extension\InvalidFormStatusExtension;
+use NetBS\CoreBundle\Form\FormResponseAttributes;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\ResponseEvent;
 
 /**
- * Bumps an HTML 200 response to 422 when the request submitted an invalid form.
- *
- * Turbo only swaps the page when a form response is a redirect or a 4xx/5xx.
- * Symfony controllers conventionally re-render the form on validation failure
- * with status 200, which Turbo silently discards — the user sees nothing
- * change after Valider. Returning 422 instead is the HTTP-semantic correct
- * status ("the server understood the request but cannot process it") and
- * Turbo handles it natively: the response body replaces the page.
- *
- * We only touch successful HTML responses; redirects, JSON, downloads, etc.
- * pass through untouched.
- *
- * Paired with {@see InvalidFormStatusExtension} which sets the request mark.
+ * Bumps a 200 HTML reply to 422 when the request submitted an invalid root form.
+ * Turbo discards non-redirect 200s on form submissions but natively re-renders
+ * 4xx — so 422 is what makes the failed-submit re-render work end-to-end.
  */
 final class InvalidFormStatusListener
 {
@@ -32,7 +22,7 @@ final class InvalidFormStatusListener
         }
 
         $request = $event->getRequest();
-        if ($request->attributes->get(InvalidFormStatusExtension::REQUEST_ATTRIBUTE) !== true) {
+        if ($request->attributes->get(FormResponseAttributes::ROOT_INVALID) !== true) {
             return;
         }
 

--- a/src/EventListener/InvalidFormStatusListener.php
+++ b/src/EventListener/InvalidFormStatusListener.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\EventListener;
+
+use App\Form\Extension\InvalidFormStatusExtension;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+
+/**
+ * Bumps an HTML 200 response to 422 when the request submitted an invalid form.
+ *
+ * Turbo only swaps the page when a form response is a redirect or a 4xx/5xx.
+ * Symfony controllers conventionally re-render the form on validation failure
+ * with status 200, which Turbo silently discards — the user sees nothing
+ * change after Valider. Returning 422 instead is the HTTP-semantic correct
+ * status ("the server understood the request but cannot process it") and
+ * Turbo handles it natively: the response body replaces the page.
+ *
+ * We only touch successful HTML responses; redirects, JSON, downloads, etc.
+ * pass through untouched.
+ *
+ * Paired with {@see InvalidFormStatusExtension} which sets the request mark.
+ */
+final class InvalidFormStatusListener
+{
+    public function __invoke(ResponseEvent $event): void
+    {
+        if (!$event->isMainRequest()) {
+            return;
+        }
+
+        $request = $event->getRequest();
+        if ($request->attributes->get(InvalidFormStatusExtension::REQUEST_ATTRIBUTE) !== true) {
+            return;
+        }
+
+        $response = $event->getResponse();
+        if ($response->getStatusCode() !== Response::HTTP_OK) {
+            return;
+        }
+
+        $contentType = strtolower($response->headers->get('Content-Type', ''));
+        if (!str_starts_with($contentType, 'text/html')
+            && !str_starts_with($contentType, 'application/xhtml+xml')) {
+            return;
+        }
+
+        $response->setStatusCode(Response::HTTP_UNPROCESSABLE_ENTITY);
+    }
+}

--- a/src/Form/CirculaireMembreType.php
+++ b/src/Form/CirculaireMembreType.php
@@ -2,18 +2,14 @@
 
 namespace App\Form;
 
-use Doctrine\ORM\EntityRepository;
+use NetBS\CoreBundle\Form\Type\AjaxSelect2DocumentType;
 use NetBS\CoreBundle\Form\Type\DateMaskType;
 use NetBS\CoreBundle\Form\Type\MaskType;
-use NetBS\CoreBundle\Form\Type\Select2DocumentType;
 use NetBS\CoreBundle\Form\Type\SexeType;
 use NetBS\CoreBundle\Form\Type\TelephoneMaskType;
-use NetBS\CoreBundle\Service\ParameterManager;
 use NetBS\CoreBundle\Utils\Countries;
-use NetBS\FichierBundle\Entity\Fonction;
 use NetBS\FichierBundle\Entity\Geniteur;
-use NetBS\FichierBundle\Select2\GroupeProvider;
-use App\Entity\BSGroupe;
+use NetBS\FichierBundle\Service\FichierConfig;
 use App\Model\CirculaireMembre;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\ChoiceType;
@@ -26,19 +22,15 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 
 class CirculaireMembreType extends AbstractType
 {
-    private $params;
+    private FichierConfig $config;
 
-    public function __construct(ParameterManager $params)
+    public function __construct(FichierConfig $config)
     {
-        $this->params = $params;
+        $this->config = $config;
     }
 
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $select2provider = new GroupeProvider();
-        $louveteauxId = $this->params->getValue('bs', 'fonction.louveteau_id');
-        $eclaireurId = $this->params->getValue('bs', 'fonction.eclaireur_id');
-
         $builder
             ->add('familleId', HiddenType::class)
             ->add('numero', NumberType::class, array('label' => "Numéro BS", 'required' => false))
@@ -59,21 +51,13 @@ class CirculaireMembreType extends AbstractType
             ->add('email', EmailType::class, array('label' => 'Email', 'required' => false))
             ->add('telephone', TelephoneMaskType::class, array('label' => 'Téléphone', 'required' => false))
             ->add('natel', TelephoneMaskType::class, array('label' => 'Natel', 'required' => false))
-            ->add('fonction', Select2DocumentType::class, array(
-                'class'         => Fonction::class,
-                'choice_label'  => 'nom',
-                'label'         => 'Fonction',
-                'query_builder' => function(EntityRepository $repository) use ($louveteauxId, $eclaireurId) {
-                    $query = $repository->createQueryBuilder('f');
-                    return $query->where($query->expr()->in('f.id', [$louveteauxId, $eclaireurId]));
-                }
+            ->add('fonction', AjaxSelect2DocumentType::class, array(
+                'label' => 'Fonction',
+                'class' => $this->config->getFonctionClass(),
             ))
-            ->add('groupe', Select2DocumentType::class, array(
-                'choice_label'  => function(BSGroupe $groupe) use ($select2provider) {
-                    return $select2provider->toString($groupe);
-                },
-                'class'         => BSGroupe::class,
-                'label'         => 'Unité'
+            ->add('groupe', AjaxSelect2DocumentType::class, array(
+                'label' => 'Unité',
+                'class' => $this->config->getGroupeClass(),
             ))
             ->add('r1statut', ChoiceType::class, [
                 'label'     => 'Statut',

--- a/src/Form/Extension/InvalidFormStatusExtension.php
+++ b/src/Form/Extension/InvalidFormStatusExtension.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Form\Extension;
+
+use Symfony\Component\Form\AbstractTypeExtension;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
+use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\Form\FormEvent;
+use Symfony\Component\Form\FormEvents;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+/**
+ * Marks the current request when any root form is submitted-and-invalid.
+ *
+ * Paired with {@see \App\EventListener\InvalidFormStatusListener}: that listener
+ * reads the mark on kernel.response and bumps a 200 HTML reply to 422. The pair
+ * lets Turbo natively handle form re-renders (Turbo respects 4xx but discards
+ * non-redirect 200s on form submissions) so every form across the app gets
+ * correct re-render behaviour without controller or template changes.
+ *
+ * Applies to every form because it extends FormType, the root of the type
+ * hierarchy.
+ */
+final class InvalidFormStatusExtension extends AbstractTypeExtension
+{
+    public const REQUEST_ATTRIBUTE = '_form_root_invalid';
+
+    public function __construct(private readonly RequestStack $requestStack)
+    {
+    }
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
+            $form = $event->getForm();
+            if (!$form->isRoot()) {
+                return;
+            }
+            if ($form->isValid()) {
+                return;
+            }
+            $request = $this->requestStack->getCurrentRequest();
+            if ($request === null) {
+                return;
+            }
+            $request->attributes->set(self::REQUEST_ATTRIBUTE, true);
+        }, /* priority */ -100);
+    }
+
+    public static function getExtendedTypes(): iterable
+    {
+        return [FormType::class];
+    }
+}

--- a/src/Form/Extension/InvalidFormStatusExtension.php
+++ b/src/Form/Extension/InvalidFormStatusExtension.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Form\Extension;
 
+use NetBS\CoreBundle\Form\FormResponseAttributes;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Core\Type\FormType;
 use Symfony\Component\Form\FormBuilderInterface;
@@ -13,20 +14,11 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Marks the current request when any root form is submitted-and-invalid.
- *
- * Paired with {@see \App\EventListener\InvalidFormStatusListener}: that listener
- * reads the mark on kernel.response and bumps a 200 HTML reply to 422. The pair
- * lets Turbo natively handle form re-renders (Turbo respects 4xx but discards
- * non-redirect 200s on form submissions) so every form across the app gets
- * correct re-render behaviour without controller or template changes.
- *
- * Applies to every form because it extends FormType, the root of the type
- * hierarchy.
+ * Paired with InvalidFormStatusListener (bumps the response to 422 so Turbo
+ * natively re-renders the form instead of discarding the 200 reply).
  */
 final class InvalidFormStatusExtension extends AbstractTypeExtension
 {
-    public const REQUEST_ATTRIBUTE = '_form_root_invalid';
-
     public function __construct(private readonly RequestStack $requestStack)
     {
     }
@@ -35,17 +27,14 @@ final class InvalidFormStatusExtension extends AbstractTypeExtension
     {
         $builder->addEventListener(FormEvents::POST_SUBMIT, function (FormEvent $event): void {
             $form = $event->getForm();
-            if (!$form->isRoot()) {
-                return;
-            }
-            if ($form->isValid()) {
+            if (!$form->isRoot() || $form->isValid()) {
                 return;
             }
             $request = $this->requestStack->getCurrentRequest();
             if ($request === null) {
                 return;
             }
-            $request->attributes->set(self::REQUEST_ATTRIBUTE, true);
+            $request->attributes->set(FormResponseAttributes::ROOT_INVALID, true);
         }, /* priority */ -100);
     }
 

--- a/src/Subscriber/DoctrineUserAccountSubscriber.php
+++ b/src/Subscriber/DoctrineUserAccountSubscriber.php
@@ -16,6 +16,7 @@ use App\Entity\LatestCreatedAccount;
 use App\Message\NextcloudGroupNotification;
 use NetBS\CoreBundle\Entity\Parameter;
 use NetBS\SecureBundle\Entity\Role;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\Mailer\MailerInterface;
 use Symfony\Component\Messenger\MessageBusInterface;
 use Symfony\Component\PasswordHasher\Hasher\UserPasswordHasherInterface;
@@ -40,8 +41,12 @@ class DoctrineUserAccountSubscriber implements EventSubscriber
 
     private $adabsId  = null;
 
-    public function __construct(UserPasswordHasherInterface $encoder, MailerInterface $mailer, MessageBusInterface $bus)
-    {
+    public function __construct(
+        UserPasswordHasherInterface $encoder,
+        MailerInterface $mailer,
+        MessageBusInterface $bus,
+        private readonly RequestStack $requestStack,
+    ) {
         $this->encoder  = $encoder;
         $this->mailer   = $mailer;
         $this->bus = $bus;
@@ -141,16 +146,33 @@ class DoctrineUserAccountSubscriber implements EventSubscriber
         if($this->roleUser === null)
             $this->roleUser = $manager->getRepository(Role::class)->findOneBy(array('role' => 'ROLE_USER'));
 
-        $username   = StrUtil::slugify($membre->getPrenom()) . "." . StrUtil::slugify($membre->getFamille()->getNom());
+        $username = StrUtil::slugify($membre->getPrenom()) . "." . StrUtil::slugify($membre->getFamille()->getNom());
+
+        // If a user with this auto-derived username already exists, skip
+        // creating an account entirely and flash a warning so the admin
+        // knows. They can then either attach the existing user to this
+        // membre or create a new user manually with a non-colliding handle.
+        $userRepo = $manager->getRepository(BSUser::class);
+        if ($userRepo->findOneBy(['username' => $username]) !== null) {
+            $session = $this->requestStack->getSession();
+            if (method_exists($session, 'getFlashBag')) {
+                $session->getFlashBag()->add(
+                    'warning',
+                    sprintf(
+                        "Le membre %s %s a été créé sans compte utilisateur : un compte « %s » existe déjà. " .
+                        "Vous pouvez attacher le compte existant à ce membre, ou créer manuellement un nouveau compte avec un identifiant différent.",
+                        $membre->getPrenom(),
+                        $membre->getFamille()->getNom(),
+                        $username
+                    )
+                );
+            }
+            return;
+        }
+
         //$password   = StrUtil::randomString();
         $password   = $username . "-" . $membre->getNaissance()->format("d-m-Y");
         $user       = new BSUser();
-        $i          = 1;
-
-        /*
-        while($manager->getRepository('SauvabelinBundle:BSUser')->findOneBy(array('username' => $username)))
-            $username   = $username . $i++;
-        */
 
         $user->setNewPasswordRequired(true);
         $user->setMembre($membre);

--- a/src/Subscriber/DoctrineUserAccountSubscriber.php
+++ b/src/Subscriber/DoctrineUserAccountSubscriber.php
@@ -148,25 +148,28 @@ class DoctrineUserAccountSubscriber implements EventSubscriber
 
         $username = StrUtil::slugify($membre->getPrenom()) . "." . StrUtil::slugify($membre->getFamille()->getNom());
 
-        // If a user with this auto-derived username already exists, skip
-        // creating an account entirely and flash a warning so the admin
-        // knows. They can then either attach the existing user to this
-        // membre or create a new user manually with a non-colliding handle.
-        $userRepo = $manager->getRepository(BSUser::class);
-        if ($userRepo->findOneBy(['username' => $username]) !== null) {
-            $session = $this->requestStack->getSession();
-            if (method_exists($session, 'getFlashBag')) {
-                $session->getFlashBag()->add(
-                    'warning',
-                    sprintf(
-                        "Le membre %s %s a été créé sans compte utilisateur : un compte « %s » existe déjà. " .
-                        "Vous pouvez attacher le compte existant à ce membre, ou créer manuellement un nouveau compte avec un identifiant différent.",
-                        $membre->getPrenom(),
-                        $membre->getFamille()->getNom(),
-                        $username
-                    )
-                );
-            }
+        // Look up including soft-deleted users — a soft-deleted user with this
+        // username would still trip the UNIQUE index on insert.
+        $filters = $manager->getFilters();
+        $filterWasEnabled = $filters->isEnabled('softdeleteable');
+        if ($filterWasEnabled) $filters->disable('softdeleteable');
+        try {
+            $collision = $manager->getRepository(BSUser::class)->findOneBy(['username' => $username]);
+        } finally {
+            if ($filterWasEnabled) $filters->enable('softdeleteable');
+        }
+
+        if ($collision !== null) {
+            $this->requestStack->getSession()->getFlashBag()->add(
+                'warning',
+                sprintf(
+                    "Le membre %s %s a été créé sans compte utilisateur : un compte « %s » existe déjà. " .
+                    "Vous pouvez attacher le compte existant à ce membre, ou créer manuellement un nouveau compte avec un identifiant différent.",
+                    $membre->getPrenom(),
+                    $membre->getFamille()->getNom(),
+                    $username
+                )
+            );
             return;
         }
 


### PR DESCRIPTION
## Summary

- Fix the broken **Nouveau membre** form: Unité/Fonction select2 widgets were non-functional, "Valider" silently 200'd without persisting, and retries lost the form state.
- Unify failed-submit handling across the app: failed submits now return **422** so Turbo re-renders in place with input preserved, a form-level error banner is rendered automatically at the top of every form, and Doctrine constraint violations attach to the form instead of triggering a redirect that wiped the user's data.

## Behavior changes

- Submitting an invalid form returns **422 Unprocessable Content** (was 200). Turbo natively handles this and re-renders the form with input intact.
- A red Bootstrap alert listing form-level errors is shown at the top of every form when present.
- Creating a *nouveau membre* whose auto-derived username (`{prenom}.{nom}`) already exists: the **membre is still created**, no user account is created, and a yellow toast warns the admin so they can either attach the existing user or create one manually.
- DB constraint violations (UNIQUE / NOT NULL / FK) now surface as a banner on the form, with the form fields preserved — they no longer redirect away or wipe the form.

## Notable files

- `src/Form/Extension/InvalidFormStatusExtension.php` — flags invalid root submits on the request.
- `src/EventListener/InvalidFormStatusListener.php` — bumps 200 → 422 on HTML responses when flagged.
- `netBS/core/CoreBundle/Controller/Trait/HandlesFormPersistenceTrait.php` — wraps `flush()`, attaches `FormError` on caught constraint violations.
- `netBS/core/CoreBundle/EventListener/DatabaseExceptionListener.php` — rewritten as last-resort safety net (no more form-clearing 303).
- `netBS/core/CoreBundle/Resources/views/form/base.theme.twig` — `form_start` banner + fixed `ajax_select2_document_widget` `dataCheck`.
- `src/Subscriber/DoctrineUserAccountSubscriber.php` — skip + warn on username collision.
- `src/Controller/MembreController.php` — resolve famille before `handleRequest`, route persistence through the trait.
- `src/Form/CirculaireMembreType.php` — switch to `AjaxSelect2DocumentType` for fonction/groupe.

## Test plan

- [x] Verified: nouveau membre with valid input → membre persisted, redirect to membre page.
- [x] Verified: nouveau membre whose username collides with existing → membre created, no user, yellow toast warning.
- [x] Verified: invalid submit → 422 + form re-renders with values preserved + banner + per-field `.is-invalid` outlining.
- [x] Verified: select2 ajax fields (fonction/groupe) function on initial render and after a failed retry.
- [ ] Sanity-check other forms across the app still render correctly (form_start banner is global).
- [ ] Verify select2 invalid-outline styling on other forms that use ajax_select2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)