### PR TITLE
feat(roles): role tree syncer + cleaner fixtures

### DIFF
--- a/assets/controllers/editable_controller.js
+++ b/assets/controllers/editable_controller.js
@@ -129,6 +129,16 @@ export default class extends Controller {
     }
 
     _buildAjaxDropdownHtml() {
+        if (this._isMulti()) {
+            return `<div class="editable-ajax-search editable-ajax-multi-wrapper position-relative" style="min-width:240px;">
+                <div class="form-control select2-multi-control d-flex flex-wrap align-items-center gap-1" style="cursor:text;">
+                    <input type="text" class="select2-multi-search editable-search-input border-0 bg-transparent p-0 flex-grow-1"
+                           style="outline:none;min-width:80px;" placeholder="Rechercher..." autocomplete="off">
+                </div>
+                <div class="list-group select2-results-dropdown editable-search-results"
+                     style="position:absolute;top:100%;left:0;width:100%;z-index:1070;max-height:250px;overflow-y:auto;display:none;background:#fff;box-shadow:0 2px 8px rgba(0,0,0,.15);"></div>
+            </div>`;
+        }
         const value = this.element.dataset.value || '';
         return `<div class="editable-ajax-search" style="min-width:220px;position:relative;">
             <input type="text" class="form-control form-control-sm editable-search-input"
@@ -137,6 +147,11 @@ export default class extends Controller {
             <div class="editable-search-results list-group"
                  style="position:absolute;top:100%;left:0;width:100%;z-index:1070;max-height:250px;overflow-y:auto;display:none;background:#fff;box-shadow:0 2px 8px rgba(0,0,0,.15);"></div>
         </div>`;
+    }
+
+    _isMulti() {
+        const m = this.element.dataset.multiple;
+        return m === '1' || m === 'true';
     }
 
     _buildSelectHtml(currentValue) {
@@ -161,8 +176,12 @@ export default class extends Controller {
             const cb = tip.querySelector('input[type="checkbox"]');
             newValue = cb.checked ? ['1'] : [''];
         } else if (this._isAjaxDropdown()) {
-            const hidden = tip.querySelector('.editable-search-value');
-            newValue = hidden ? hidden.value : '';
+            if (this._isMulti()) {
+                newValue = Array.from(tip.querySelectorAll('.select2-tag')).map((t) => t.dataset.id);
+            } else {
+                const hidden = tip.querySelector('.editable-search-value');
+                newValue = hidden ? hidden.value : '';
+            }
         } else if (type === 'hochetdatepicker') {
             const input = tip.querySelector('.editable-flatpickr');
             newValue = input.value;
@@ -198,7 +217,11 @@ export default class extends Controller {
                 });
             })
             .then((data) => {
-                this._updateDisplayValue(type, newValue, data);
+                if (this._isAjaxDropdown() && this._isMulti()) {
+                    this._updateMultiDisplay(tip);
+                } else {
+                    this._updateDisplayValue(type, newValue, data);
+                }
                 this._destroyPopover();
                 showToast('success', 'Valeur modifiée avec succès');
             })
@@ -236,6 +259,10 @@ export default class extends Controller {
 
 
     _wireAjaxSearch(tip) {
+        if (this._isMulti()) {
+            this._wireAjaxMultiSearch(tip);
+            return;
+        }
         const searchInput = tip.querySelector('.editable-search-input');
         const hiddenInput = tip.querySelector('.editable-search-value');
         const results = tip.querySelector('.editable-search-results');
@@ -257,6 +284,89 @@ export default class extends Controller {
             searchInput.value = item.dataset.text;
             results.style.display = 'none';
         });
+    }
+
+    _wireAjaxMultiSearch(tip) {
+        const control = tip.querySelector('.select2-multi-control');
+        const searchInput = tip.querySelector('.editable-search-input');
+        const results = tip.querySelector('.editable-search-results');
+        const ajaxClass = this.element.dataset.ajaxClass;
+        const nullOption = this.element.dataset.nullOption || '0';
+        const url = this.element.dataset.editableSelect2UrlValue || '/netBS/netbs/select2/results';
+
+        const sourceById = {};
+        for (const it of this._parseJsonArray(this.element.dataset.originalSource)) {
+            sourceById[String(it.id)] = it.text;
+        }
+        for (const id of this._parseJsonArray(this.element.dataset.value)) {
+            this._addTag(control, searchInput, String(id), sourceById[String(id)] || String(id));
+        }
+
+        control.addEventListener('click', (e) => {
+            if (e.target === control) searchInput.focus();
+        });
+
+        searchInput.addEventListener('focus', () => {
+            results.style.display = 'block';
+            fetchResults(url, ajaxClass, '', nullOption).then((items) => renderDropdownItems(items, results));
+        });
+
+        wireSearchInput(searchInput, results, (query) => {
+            results.style.display = 'block';
+            fetchResults(url, ajaxClass, query, nullOption).then((items) => renderDropdownItems(items, results));
+        });
+
+        results.addEventListener('click', (e) => {
+            e.preventDefault();
+            const item = e.target.closest('[data-id]');
+            if (!item) return;
+            if (!control.querySelector(`.select2-tag[data-id="${CSS.escape(item.dataset.id)}"]`)) {
+                this._addTag(control, searchInput, item.dataset.id, item.dataset.text);
+            }
+            searchInput.value = '';
+            results.style.display = 'none';
+            searchInput.focus();
+        });
+    }
+
+    _addTag(control, searchInput, id, text) {
+        const tag = document.createElement('span');
+        tag.className = 'select2-tag badge bg-primary d-inline-flex align-items-center gap-1';
+        tag.dataset.id = id;
+        const label = document.createElement('span');
+        label.className = 'select2-tag-text';
+        label.textContent = text;
+        const close = document.createElement('button');
+        close.type = 'button';
+        close.className = 'btn-close btn-close-white';
+        close.style.fontSize = '.6em';
+        close.setAttribute('aria-label', 'Retirer');
+        close.addEventListener('click', () => tag.remove());
+        tag.appendChild(label);
+        tag.appendChild(close);
+        control.insertBefore(tag, searchInput);
+    }
+
+    _updateMultiDisplay(tip) {
+        const tagEls = tip.querySelectorAll('.select2-tag');
+        const tagData = Array.from(tagEls).map((t) => ({
+            id: t.dataset.id,
+            text: t.querySelector('.select2-tag-text').textContent,
+        }));
+        const empty = this.element.dataset.emptytext || 'Rien';
+        this.element.textContent = tagData.length === 0 ? empty : `${tagData.length} élément(s)`;
+        this.element.dataset.value = JSON.stringify(tagData.map((t) => t.id));
+        this.element.dataset.originalSource = JSON.stringify(tagData);
+    }
+
+    _parseJsonArray(raw) {
+        if (!raw) return [];
+        try {
+            const v = JSON.parse(raw);
+            return Array.isArray(v) ? v : [];
+        } catch (e) {
+            return [];
+        }
     }
 
 

--- a/assets/controllers/editable_controller.js
+++ b/assets/controllers/editable_controller.js
@@ -1,6 +1,6 @@
 import { Controller } from '@hotwired/stimulus';
 import { showToast } from '../lib/toast.js';
-import { fetchResults, renderDropdownItems, wireSearchInput, esc } from '../lib/ajax_search.js';
+import { fetchResults, renderDropdownItems, wireSearchInput, parseJsonArray, esc } from '../lib/ajax_search.js';
 
 export default class extends Controller {
 
@@ -295,20 +295,15 @@ export default class extends Controller {
         const url = this.element.dataset.editableSelect2UrlValue || '/netBS/netbs/select2/results';
 
         const sourceById = {};
-        for (const it of this._parseJsonArray(this.element.dataset.originalSource)) {
+        for (const it of parseJsonArray(this.element.dataset.originalSource)) {
             sourceById[String(it.id)] = it.text;
         }
-        for (const id of this._parseJsonArray(this.element.dataset.value)) {
-            this._addTag(control, searchInput, String(id), sourceById[String(id)] || String(id));
+        for (const id of parseJsonArray(this.element.dataset.value)) {
+            this._addTag(tip, String(id), sourceById[String(id)] || String(id));
         }
 
         control.addEventListener('click', (e) => {
             if (e.target === control) searchInput.focus();
-        });
-
-        searchInput.addEventListener('focus', () => {
-            results.style.display = 'block';
-            fetchResults(url, ajaxClass, '', nullOption).then((items) => renderDropdownItems(items, results));
         });
 
         wireSearchInput(searchInput, results, (query) => {
@@ -321,7 +316,7 @@ export default class extends Controller {
             const item = e.target.closest('[data-id]');
             if (!item) return;
             if (!control.querySelector(`.select2-tag[data-id="${CSS.escape(item.dataset.id)}"]`)) {
-                this._addTag(control, searchInput, item.dataset.id, item.dataset.text);
+                this._addTag(tip, item.dataset.id, item.dataset.text);
             }
             searchInput.value = '';
             results.style.display = 'none';
@@ -329,7 +324,9 @@ export default class extends Controller {
         });
     }
 
-    _addTag(control, searchInput, id, text) {
+    _addTag(tip, id, text) {
+        const control = tip.querySelector('.select2-multi-control');
+        const searchInput = tip.querySelector('.editable-search-input');
         const tag = document.createElement('span');
         tag.className = 'select2-tag badge bg-primary d-inline-flex align-items-center gap-1';
         tag.dataset.id = id;
@@ -359,15 +356,6 @@ export default class extends Controller {
         this.element.dataset.originalSource = JSON.stringify(tagData);
     }
 
-    _parseJsonArray(raw) {
-        if (!raw) return [];
-        try {
-            const v = JSON.parse(raw);
-            return Array.isArray(v) ? v : [];
-        } catch (e) {
-            return [];
-        }
-    }
 
 
     async _initFlatpickr(input) {

--- a/assets/lib/ajax_search.js
+++ b/assets/lib/ajax_search.js
@@ -12,12 +12,15 @@ export function fetchResults(url, ajaxClass, query, nullOption) {
 }
 
 export function renderDropdownItems(items, container) {
-    container.innerHTML = items.map((item) =>
-        `<a href="#" class="list-group-item list-group-item-action py-1 px-2"
+    container.innerHTML = items.map((item) => {
+        const subtitle = item.subtitle
+            ? `<div class="small text-muted">${esc(item.subtitle)}</div>`
+            : '';
+        return `<a href="#" class="list-group-item list-group-item-action py-1 px-2"
             data-id="${esc(item.id)}" data-text="${esc(item.text)}">
-            ${esc(item.text)}
-        </a>`
-    ).join('') || '<span class="list-group-item py-1 px-2 text-muted">Aucun résultat</span>';
+            <div>${esc(item.text)}</div>${subtitle}
+        </a>`;
+    }).join('') || '<span class="list-group-item py-1 px-2 text-muted">Aucun résultat</span>';
     container.style.display = 'block';
 }
 
@@ -31,6 +34,16 @@ export function wireSearchInput(input, resultsContainer, searchFn) {
 
     input.addEventListener('focus', () => doSearch(input.value.trim()));
     input.addEventListener('input', () => doSearch(input.value.trim()));
+}
+
+export function parseJsonArray(raw) {
+    if (!raw) return [];
+    try {
+        const v = JSON.parse(raw);
+        return Array.isArray(v) ? v : [];
+    } catch (e) {
+        return [];
+    }
 }
 
 export function esc(str) {

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,10 @@
             "NetBS\\ListBundle\\": "netBS/core/ListBundle",
             "Ovesco\\FacturationBundle\\": "netBS/ovesco/FacturationBundle",
             "Iacopo\\MailingBundle\\": "netBS/iacopo/MailingBundle"
-        }
+        },
+        "classmap": [
+            "netBS/core/SecureBundle/Audit/AccessAudit.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -165,6 +165,12 @@ services:
     arguments:
       $manager: "@doctrine.orm.default_entity_manager"
 
+  # Picked up by SecureBundle's RoleTreeSyncer via the netbs.role_tree_source tag.
+  # The tag is set explicitly because SecureBundle's _instanceof rule only
+  # applies within its own services.yml file.
+  App\Service\AppRoleTreeSource:
+    tags: ['netbs.role_tree_source']
+
 imports:
   - { resource: "@NetBSCoreBundle/Resources/config/services.yml" }
   - { resource: "@NetBSFichierBundle/Resources/config/services.yml" }

--- a/netBS/core/CoreBundle/Controller/Select2Controller.php
+++ b/netBS/core/CoreBundle/Controller/Select2Controller.php
@@ -41,7 +41,14 @@ class Select2Controller extends AbstractController
             }
 
             if ($ok) {
-                $results[] = ['id' => $provider->toId($item), 'text' => $provider->toString($item)];
+                $row = ['id' => $provider->toId($item), 'text' => $provider->toString($item)];
+                if (method_exists($provider, 'toSubtitle')) {
+                    $subtitle = $provider->toSubtitle($item);
+                    if ($subtitle !== null && $subtitle !== '') {
+                        $row['subtitle'] = $subtitle;
+                    }
+                }
+                $results[] = $row;
             }
         }
 

--- a/netBS/core/FichierBundle/DataFixtures/LoadRolesData.php
+++ b/netBS/core/FichierBundle/DataFixtures/LoadRolesData.php
@@ -6,54 +6,19 @@ use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use NetBS\SecureBundle\Entity\Role;
-use NetBS\SecureBundle\Service\SecureConfig;
-use Symfony\Component\Yaml\Yaml;
 
+/**
+ * SecureBundle's LoadRolesData (order 1) already calls RoleTreeSyncer, which
+ * walks every tagged source — including FichierBundle's FichierRoleTreeSource.
+ * So this fixture has nothing left to do; it's kept as an empty stub to
+ * preserve any ordering expectations downstream fixtures might have.
+ */
 class LoadRolesData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
-    protected $secureConfig;
-
-    public function __construct(SecureConfig $config) {
-        $this->secureConfig = $config;
-    }
-
     public function load(ObjectManager $manager): void
     {
-        $config = Yaml::parse(file_get_contents(__DIR__ . "/../Resources/security/roles.yml"));
-        $roles  = $this->loadRole($config['roles'], $manager);
-
-        foreach($roles as $role) {
-
-            $role->setParent($this->getReference('ROLE_ADMIN', Role::class));
-            $manager->persist($role);
-        }
-
-        $manager->flush();
-    }
-
-    public function loadRole(array $data, ObjectManager $manager) {
-
-        $roleClass  = $this->secureConfig->getRoleClass();
-        $roles  = [];
-
-        foreach($data as $name => $params) {
-
-            $role   = new $roleClass($name, $params['poids'], $params['description']);
-
-            if(isset($params['children'])) {
-
-                $childs = $this->loadRole($params['children'], $manager);
-
-                foreach($childs as $child)
-                    $role->addChild($child);
-            }
-
-            $manager->persist($role);
-            $roles[] = $role;
-        }
-
-        return $roles;
+        // No-op: roles are reconciled via the shared RoleTreeSyncer service,
+        // invoked from SecureBundle's LoadRolesData (order 1).
     }
 
     public static function getGroups(): array

--- a/netBS/core/FichierBundle/Resources/config/services.yml
+++ b/netBS/core/FichierBundle/Resources/config/services.yml
@@ -42,6 +42,13 @@ services:
 
     NetBS\FichierBundle\Service\MesUnitesResolver: ~
 
+    # Picked up by SecureBundle's RoleTreeSyncer via the netbs.role_tree_source
+    # tag. The tag is set explicitly here because Symfony's _instanceof rule
+    # only applies within the services.yml file that declares it, and the rule
+    # lives in SecureBundle.
+    NetBS\FichierBundle\Service\FichierRoleTreeSource:
+        tags: ['netbs.role_tree_source']
+
     NetBS\FichierBundle\Searcher\ActiveAttributionBinder:
         tags:
             - { name: netbs.searcher.binder }

--- a/netBS/core/FichierBundle/Resources/security/roles.yml
+++ b/netBS/core/FichierBundle/Resources/security/roles.yml
@@ -3,44 +3,44 @@
 # not declared here.
 roles:
     ROLE_SG:
-        description: "Secrétaire général. ACCÈS GLOBAL au fichier : court-circuite tous les voters Fichier (Membre, Famille, Groupe, Attribution, Distinction) via FichierVoter::specialRule. Seul rôle autorisé à accéder à l'historique d'audit (/audit-log) et à la corbeille (/trash), et à créer/modifier des attributions et obtentions de distinction. Parent des quatre rôles ROLE_*_EVERYWHERE."
+        description: "Accès complet au fichier sur tous les groupes. Seul à voir l'historique d'audit et la corbeille."
         poids: 80000
         children:
             ROLE_CREATE_EVERYWHERE:
-                description: "ACCÈS GLOBAL : crée des entités du fichier (membres, familles, groupes, distinctions, fonctions, catégories, types) dans n'importe quel groupe sans autorisation explicite. Court-circuite GroupeVoter pour l'opération 'create'. Requis pour /distinction/new, /groupe/new, /fonction/new, /mass-adder. Parent de ROLE_CREATE."
+                description: "Création de membres, familles, groupes et autres entités dans n'importe quel groupe."
                 poids: 100
                 children:
                     ROLE_CREATE:
-                        description: "Crée des entités du fichier dans un groupe pour lequel l'utilisateur a une autorisation (Autorisation OU Fonction). Le voter exige que l'autorisation porte un rôle dont le nom contient 'CREATE' — typiquement ROLE_CREATE lui-même ou ROLE_CREATE_ATTRIBUTION."
+                        description: "Création d'entités dans les groupes où l'utilisateur a une autorisation."
                         poids: 50
                     ROLE_CREATE_ATTRIBUTION:
-                        description: "Permet de créer des attributions (membre × fonction × groupe) dans un groupe autorisé. Voté par AttributionVoter."
+                        description: "Attribution de fonctions à des membres dans les groupes autorisés."
                         poids: 60
 
             ROLE_READ_EVERYWHERE:
-                description: "ACCÈS GLOBAL en lecture sur tout le fichier : court-circuite GroupeVoter pour l'opération 'read'. Débloque les listes automatiques (/listes-automatiques) et l'accès au menu 'Listes' en sidebar. Parent de ROLE_READ."
+                description: "Consultation de tous les groupes. Débloque les listes automatiques."
                 poids: 100
                 children:
                     ROLE_READ:
-                        description: "Lit les entités d'un groupe pour lequel l'utilisateur a une autorisation. Rôle le plus distribué — accordé par presque toutes les fonctions via leur attribution. Le voter exige que l'autorisation porte un rôle dont le nom contient 'READ'."
+                        description: "Consultation des groupes où l'utilisateur a une autorisation."
                         poids: 50
 
             ROLE_UPDATE_EVERYWHERE:
-                description: "ACCÈS GLOBAL en mise à jour : court-circuite GroupeVoter pour l'opération 'update'. Débloque l'éditeur de masse (/mass-updater). Parent de ROLE_UPDATE."
+                description: "Modification de n'importe quelle entité du fichier. Débloque l'éditeur de masse."
                 poids: 100
                 children:
                     ROLE_UPDATE:
-                        description: "Met à jour les entités d'un groupe pour lequel l'utilisateur a une autorisation. Le voter exige que l'autorisation porte un rôle dont le nom contient 'UPDATE'."
+                        description: "Modification des entités dans les groupes autorisés."
                         poids: 50
 
             ROLE_DELETE_EVERYWHERE:
-                description: "ACCÈS GLOBAL en suppression : court-circuite GroupeVoter pour l'opération 'delete'. Parent de ROLE_DELETE."
+                description: "Suppression de n'importe quelle entité du fichier."
                 poids: 100
                 children:
                     ROLE_DELETE:
-                        description: "Supprime les entités d'un groupe pour lequel l'utilisateur a une autorisation. Le voter exige que l'autorisation porte un rôle dont le nom contient 'DELETE'. Suppression douce (soft-delete) : restauration possible depuis la corbeille (ROLE_SG)."
+                        description: "Suppression des entités dans les groupes autorisés. Restauration possible via la corbeille."
                         poids: 50
 
     ROLE_IT:
-        description: "Responsable informatique. Rôle de tagging — n'octroie aucune permission métier par lui-même, sert à identifier l'équipe IT (typiquement pour mailings et listes automatiques). Le pouvoir admin réel passe par ROLE_ADMIN."
+        description: "Étiquette servant aux mailings et listes automatiques. Aucun droit propre."
         poids: 80000

--- a/netBS/core/FichierBundle/Resources/security/roles.yml
+++ b/netBS/core/FichierBundle/Resources/security/roles.yml
@@ -3,44 +3,44 @@
 # not declared here.
 roles:
     ROLE_SG:
-        description: "Secrétaire général"
+        description: "Secrétaire général. ACCÈS GLOBAL au fichier : court-circuite tous les voters Fichier (Membre, Famille, Groupe, Attribution, Distinction) via FichierVoter::specialRule. Seul rôle autorisé à accéder à l'historique d'audit (/audit-log) et à la corbeille (/trash), et à créer/modifier des attributions et obtentions de distinction. Parent des quatre rôles ROLE_*_EVERYWHERE."
         poids: 80000
         children:
             ROLE_CREATE_EVERYWHERE:
-                description: "Permet de créer des entités partout dans le fichier"
+                description: "ACCÈS GLOBAL : crée des entités du fichier (membres, familles, groupes, distinctions, fonctions, catégories, types) dans n'importe quel groupe sans autorisation explicite. Court-circuite GroupeVoter pour l'opération 'create'. Requis pour /distinction/new, /groupe/new, /fonction/new, /mass-adder. Parent de ROLE_CREATE."
                 poids: 100
                 children:
                     ROLE_CREATE:
-                        description: "Permet de créer des entités dans un groupe"
+                        description: "Crée des entités du fichier dans un groupe pour lequel l'utilisateur a une autorisation (Autorisation OU Fonction). Le voter exige que l'autorisation porte un rôle dont le nom contient 'CREATE' — typiquement ROLE_CREATE lui-même ou ROLE_CREATE_ATTRIBUTION."
                         poids: 50
                     ROLE_CREATE_ATTRIBUTION:
-                        description: "Permet de créer des attributions"
+                        description: "Permet de créer des attributions (membre × fonction × groupe) dans un groupe autorisé. Voté par AttributionVoter."
                         poids: 60
 
             ROLE_READ_EVERYWHERE:
-                description: "Permet de consulter des entités partout dans le fichier"
+                description: "ACCÈS GLOBAL en lecture sur tout le fichier : court-circuite GroupeVoter pour l'opération 'read'. Débloque les listes automatiques (/listes-automatiques) et l'accès au menu 'Listes' en sidebar. Parent de ROLE_READ."
                 poids: 100
                 children:
                     ROLE_READ:
-                        description: "Permet de voir les entités d'un groupe"
+                        description: "Lit les entités d'un groupe pour lequel l'utilisateur a une autorisation. Rôle le plus distribué — accordé par presque toutes les fonctions via leur attribution. Le voter exige que l'autorisation porte un rôle dont le nom contient 'READ'."
                         poids: 50
 
             ROLE_UPDATE_EVERYWHERE:
-                description: "Permet de mettre à jour des entités partout dans le fichier"
+                description: "ACCÈS GLOBAL en mise à jour : court-circuite GroupeVoter pour l'opération 'update'. Débloque l'éditeur de masse (/mass-updater). Parent de ROLE_UPDATE."
                 poids: 100
                 children:
                     ROLE_UPDATE:
-                        description: "Permet de mettre à jour les entités d'un groupe"
+                        description: "Met à jour les entités d'un groupe pour lequel l'utilisateur a une autorisation. Le voter exige que l'autorisation porte un rôle dont le nom contient 'UPDATE'."
                         poids: 50
 
             ROLE_DELETE_EVERYWHERE:
-                description: "Permet de supprimer des entités partout dans le fichier"
+                description: "ACCÈS GLOBAL en suppression : court-circuite GroupeVoter pour l'opération 'delete'. Parent de ROLE_DELETE."
                 poids: 100
                 children:
                     ROLE_DELETE:
-                        description: "Permet de supprimer les entités d'un groupe"
+                        description: "Supprime les entités d'un groupe pour lequel l'utilisateur a une autorisation. Le voter exige que l'autorisation porte un rôle dont le nom contient 'DELETE'. Suppression douce (soft-delete) : restauration possible depuis la corbeille (ROLE_SG)."
                         poids: 50
 
     ROLE_IT:
-        description: "Responsable IT"
+        description: "Responsable informatique. Rôle de tagging — n'octroie aucune permission métier par lui-même, sert à identifier l'équipe IT (typiquement pour mailings et listes automatiques). Le pouvoir admin réel passe par ROLE_ADMIN."
         poids: 80000

--- a/netBS/core/FichierBundle/Resources/security/roles.yml
+++ b/netBS/core/FichierBundle/Resources/security/roles.yml
@@ -1,46 +1,46 @@
+# Generic file-domain roles. Grafted under ROLE_COMMANDANT (provided by the
+# app-level structure YAML). ROLE_COMMANDANT itself is org-specific and is
+# not declared here.
 roles:
-    ROLE_COMMANDANT:
-        description: "Commandant de la brigade"
-        poids: 1000
+    ROLE_SG:
+        description: "Secrétaire général"
+        poids: 80000
         children:
-            ROLE_SG:
-                description: "Secrétaire général"
-                poids: 80000
+            ROLE_CREATE_EVERYWHERE:
+                description: "Permet de créer des entités partout dans le fichier"
+                poids: 100
                 children:
-                    ROLE_CREATE_EVERYWHERE:
-                        description: "Permet de créer des entités partout dans le fichier"
-                        poids: 100
-                        children:
-                            ROLE_CREATE:
-                                description: "Permet de créer des entités dans un groupe"
-                                poids: 50
+                    ROLE_CREATE:
+                        description: "Permet de créer des entités dans un groupe"
+                        poids: 50
+                    ROLE_CREATE_ATTRIBUTION:
+                        description: "Permet de créer des attributions"
+                        poids: 60
 
-                    ROLE_READ_EVERYWHERE:
-                        description: "Permet de consulter des entités partout dans le fichier"
-                        poids: 100
-                        children:
-                            ROLE_READ:
-                                description: "Permet de voir les entités d'un groupe"
-                                poids: 50
+            ROLE_READ_EVERYWHERE:
+                description: "Permet de consulter des entités partout dans le fichier"
+                poids: 100
+                children:
+                    ROLE_READ:
+                        description: "Permet de voir les entités d'un groupe"
+                        poids: 50
 
-                    ROLE_UPDATE_EVERYWHERE:
-                        description: "Permet de mettre à jour des entités partout dans le fichier"
-                        poids: 100
-                        children:
-                            ROLE_UPDATE:
-                                description: "Permet de mettre à jour les entités d'un groupe"
-                                poids: 50
+            ROLE_UPDATE_EVERYWHERE:
+                description: "Permet de mettre à jour des entités partout dans le fichier"
+                poids: 100
+                children:
+                    ROLE_UPDATE:
+                        description: "Permet de mettre à jour les entités d'un groupe"
+                        poids: 50
 
-                    ROLE_DELETE_EVERYWHERE:
-                        description: "Permet de supprimer des entités partout dans le fichier"
-                        poids: 100
-                        children:
-                            ROLE_DELETE:
-                                description: "Permet de supprimer les entités d'un groupe"
-                                poids: 50
-            ROLE_IT:
-                description: "Responsable IT"
-                poids: 80000
-            ROLE_MAILING:
-                description: "Gestionnaire des listes de diffusion"
-                poids: 980
+            ROLE_DELETE_EVERYWHERE:
+                description: "Permet de supprimer des entités partout dans le fichier"
+                poids: 100
+                children:
+                    ROLE_DELETE:
+                        description: "Permet de supprimer les entités d'un groupe"
+                        poids: 50
+
+    ROLE_IT:
+        description: "Responsable IT"
+        poids: 80000

--- a/netBS/core/FichierBundle/Service/FichierRoleTreeSource.php
+++ b/netBS/core/FichierBundle/Service/FichierRoleTreeSource.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\FichierBundle\Service;
+
+use NetBS\SecureBundle\Service\RoleTreeSourceInterface;
+
+/**
+ * Grafts the generic file-domain role subtree (ROLE_SG, ROLE_IT, and the
+ * CRUD chain under ROLE_SG) onto ROLE_COMMANDANT.
+ *
+ * ROLE_COMMANDANT itself is org-specific and is declared by the app-level
+ * source (src/Resources/structure/roles.yml). Order 600 ensures App's
+ * source (order 500) has run first and created ROLE_COMMANDANT before this
+ * source tries to look it up as a graft point.
+ */
+final class FichierRoleTreeSource implements RoleTreeSourceInterface
+{
+    public function getYamlPath(): string
+    {
+        return __DIR__ . '/../Resources/security/roles.yml';
+    }
+
+    public function getRootParent(): ?string
+    {
+        return 'ROLE_COMMANDANT';
+    }
+
+    public function getOrder(): int
+    {
+        return 600;
+    }
+}

--- a/netBS/core/SecureBundle/Audit/AccessAudit.php
+++ b/netBS/core/SecureBundle/Audit/AccessAudit.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Audit;
+
+use NetBS\FichierBundle\Mapping\BaseFonction;
+use NetBS\FichierBundle\Mapping\BaseGroupe;
+use NetBS\SecureBundle\Mapping\BaseRole;
+use NetBS\SecureBundle\Mapping\BaseUser;
+
+enum Provenance: string
+{
+    case DIRECT_ROLE = 'direct_role';      // user.roles
+    case FONCTION_ROLE = 'fonction_role';  // user.membre.activesAttributions[].fonction.roles
+    case AUTORISATION = 'autorisation';    // user.autorisations[]
+}
+
+final readonly class AccessGrant
+{
+    /** @param BaseRole[] $roles  Recursive children already expanded. */
+    public function __construct(
+        public Provenance $provenance,
+        public ?BaseFonction $sourceFonction,  // set for FONCTION_ROLE only
+        public array $roles,
+        public ?BaseGroupe $scope,             // null for DIRECT_ROLE (global)
+        public ?int $sourceId = null,          // attribution.id / autorisation.id, for deep links
+    ) {}
+}
+
+final readonly class UserAccessReport
+{
+    /** @param AccessGrant[] $grants */
+    public function __construct(public BaseUser $user, public array $grants) {}
+}
+
+final readonly class ScopeAccessEntry
+{
+    /** @param AccessGrant[] $grants */
+    public function __construct(public BaseUser $user, public array $grants) {}
+}
+
+final readonly class ScopeAccessReport
+{
+    /** @param ScopeAccessEntry[] $entries */
+    public function __construct(
+        public BaseGroupe|BaseRole $scope,
+        public array $entries,
+    ) {}
+}

--- a/netBS/core/SecureBundle/Audit/AccessAudit.php
+++ b/netBS/core/SecureBundle/Audit/AccessAudit.php
@@ -30,8 +30,17 @@ final readonly class AccessGrant
 
 final readonly class UserAccessReport
 {
-    /** @param AccessGrant[] $grants */
-    public function __construct(public BaseUser $user, public array $grants) {}
+    /**
+     * @param AccessGrant[] $grants
+     * @param int $sensitiveRoleCount Distinct sensitive role names this user effectively holds.
+     * @param int $scopeCount         Distinct scopes (Groupes) this user has access to.
+     */
+    public function __construct(
+        public BaseUser $user,
+        public array $grants,
+        public int $sensitiveRoleCount = 0,
+        public int $scopeCount = 0,
+    ) {}
 }
 
 final readonly class ScopeAccessEntry

--- a/netBS/core/SecureBundle/Audit/AccessAudit.php
+++ b/netBS/core/SecureBundle/Audit/AccessAudit.php
@@ -57,3 +57,16 @@ final readonly class ScopeAccessReport
         public array $entries,
     ) {}
 }
+
+/**
+ * One cell of the sensitive-role matrix: the grants by which a user holds a role,
+ * plus whether at least one path is explicit (vs. inherited via an ancestor role).
+ */
+final readonly class SensitiveRoleCell
+{
+    /** @param AccessGrant[] $grants */
+    public function __construct(
+        public array $grants,
+        public bool $explicit,
+    ) {}
+}

--- a/netBS/core/SecureBundle/Audit/AccessAudit.php
+++ b/netBS/core/SecureBundle/Audit/AccessAudit.php
@@ -18,11 +18,18 @@ enum Provenance: string
 
 final readonly class AccessGrant
 {
-    /** @param BaseRole[] $roles  Recursive children already expanded. */
+    /**
+     * @param BaseRole[] $roles               Recursive children already expanded.
+     * @param string[]   $explicitRoleNames   Names of the roles in $roles that are literally
+     *                                        held on this path (i.e. were in the source collection,
+     *                                        not gained by tree expansion). Roles in $roles whose
+     *                                        names are NOT in this set are inherited.
+     */
     public function __construct(
         public Provenance $provenance,
         public ?BaseFonction $sourceFonction,  // set for FONCTION_ROLE only
         public array $roles,
+        public array $explicitRoleNames,
         public ?BaseGroupe $scope,             // null for DIRECT_ROLE (global)
         public ?int $sourceId = null,          // attribution.id / autorisation.id, for deep links
     ) {}

--- a/netBS/core/SecureBundle/Command/DebugUserRolesCommand.php
+++ b/netBS/core/SecureBundle/Command/DebugUserRolesCommand.php
@@ -6,6 +6,7 @@ namespace NetBS\SecureBundle\Command;
 
 use Doctrine\ORM\EntityManagerInterface;
 use App\Entity\BSUser;
+use NetBS\SecureBundle\Service\AccessAuditService;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -47,7 +48,7 @@ final class DebugUserRolesCommand extends Command
         }
 
         $output->writeln("");
-        foreach (['ROLE_ADMIN', 'ROLE_COMMANDANT', 'ROLE_SG', 'ROLE_READ_EVERYWHERE', 'ROLE_APMBS', 'ROLE_TRESORIER'] as $r) {
+        foreach (AccessAuditService::SENSITIVE_ROLES as $r) {
             $output->writeln(sprintf("hasRole %-25s : %s", $r, $user->hasRole($r) ? 'YES' : 'no'));
         }
 

--- a/netBS/core/SecureBundle/Command/DebugUserRolesCommand.php
+++ b/netBS/core/SecureBundle/Command/DebugUserRolesCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use App\Entity\BSUser;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+#[AsCommand(name: 'netbs:debug:user-roles')]
+final class DebugUserRolesCommand extends Command
+{
+    public function __construct(private readonly EntityManagerInterface $em)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('username', InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $username = $input->getArgument('username');
+        $user = $this->em->getRepository(BSUser::class)->findOneBy(['loginUsername' => $username])
+            ?? $this->em->getRepository(BSUser::class)->findOneBy(['username' => $username]);
+
+        if (!$user) {
+            $output->writeln("<error>User '$username' not found.</error>");
+            return Command::FAILURE;
+        }
+
+        $output->writeln("User: {$user->getLoginUsername()} (id={$user->getId()})");
+        $output->writeln("\nDirect roles:");
+        foreach ($user->getDirectRoles() as $r) {
+            $output->writeln("  - " . $r->getRole());
+        }
+
+        $output->writeln("\nAll roles (getAllRoles, via getChildrenRecursive):");
+        foreach ($user->getAllRoles() as $r) {
+            $output->writeln("  - " . $r->getRole());
+        }
+
+        $output->writeln("");
+        foreach (['ROLE_ADMIN', 'ROLE_COMMANDANT', 'ROLE_SG', 'ROLE_READ_EVERYWHERE', 'ROLE_APMBS', 'ROLE_TRESORIER'] as $r) {
+            $output->writeln(sprintf("hasRole %-25s : %s", $r, $user->hasRole($r) ? 'YES' : 'no'));
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/netBS/core/SecureBundle/Command/DebugUserRolesCommand.php
+++ b/netBS/core/SecureBundle/Command/DebugUserRolesCommand.php
@@ -28,15 +28,14 @@ final class DebugUserRolesCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $username = $input->getArgument('username');
-        $user = $this->em->getRepository(BSUser::class)->findOneBy(['loginUsername' => $username])
-            ?? $this->em->getRepository(BSUser::class)->findOneBy(['username' => $username]);
+        $user = $this->em->getRepository(BSUser::class)->findOneBy(['username' => $username]);
 
         if (!$user) {
             $output->writeln("<error>User '$username' not found.</error>");
             return Command::FAILURE;
         }
 
-        $output->writeln("User: {$user->getLoginUsername()} (id={$user->getId()})");
+        $output->writeln("User: {$user->getUsername()} (id={$user->getId()})");
         $output->writeln("\nDirect roles:");
         foreach ($user->getDirectRoles() as $r) {
             $output->writeln("  - " . $r->getRole());

--- a/netBS/core/SecureBundle/Command/SyncRolesCommand.php
+++ b/netBS/core/SecureBundle/Command/SyncRolesCommand.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use NetBS\SecureBundle\Service\RoleTreeSyncer;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * Reconcile the role tree in `netbs_secure_roles` with the YAML definitions
+ * supplied by every bundle that tags a `RoleTreeSourceInterface` service.
+ *
+ * Safe to run on production: only the `netbs_secure_roles` table is touched.
+ * No user, fonction, membre, autorisation, or other data is read or written.
+ * Existing role rows are updated in place (poids / description / parent_id);
+ * missing rows are inserted; orphan rows (in DB but not in any YAML) are
+ * surfaced as a warning but never deleted automatically.
+ */
+#[AsCommand(
+    name: 'netbs:roles:sync',
+    description: 'Reconcile the role tree in the database with the YAML role definitions.',
+)]
+final class SyncRolesCommand extends Command
+{
+    public function __construct(
+        private readonly RoleTreeSyncer $syncer,
+        private readonly EntityManagerInterface $em,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Sync roles from YAML to database');
+
+        $report = $this->syncer->syncAll();
+
+        if ($report->dedupedFrom > 0) {
+            $io->note(sprintf('Removed %d duplicate role row(s) before syncing.', $report->dedupedFrom));
+        }
+
+        if (!empty($report->created)) {
+            $io->section(sprintf('Created (%d)', count($report->created)));
+            $io->listing($report->created);
+        }
+        if (!empty($report->updated)) {
+            $io->section(sprintf('Updated (%d)', count($report->updated)));
+            $io->listing($report->updated);
+        }
+        $io->writeln(sprintf('Unchanged: %d', count($report->unchanged)));
+
+        $touched = array_merge($report->created, $report->updated, $report->unchanged);
+        $orphans = $this->detectOrphans($touched);
+        if (!empty($orphans)) {
+            $io->warning(
+                'These roles exist in the database but are not in any YAML: '
+                . implode(', ', $orphans)
+                . '. They are left as-is. Add them to a YAML source or remove them manually if intended.'
+            );
+        }
+
+        $io->success('Roles synced.');
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param string[] $touched Role names produced by the syncer this run.
+     * @return string[] Role names in the DB that the syncer did not touch.
+     */
+    private function detectOrphans(array $touched): array
+    {
+        $allNames = array_column(
+            $this->em->getConnection()->fetchAllAssociative('SELECT role FROM netbs_secure_roles'),
+            'role'
+        );
+        $orphans = array_values(array_diff($allNames, $touched));
+        sort($orphans);
+        return $orphans;
+    }
+}

--- a/netBS/core/SecureBundle/Controller/AuditController.php
+++ b/netBS/core/SecureBundle/Controller/AuditController.php
@@ -47,9 +47,9 @@ final class AuditController extends AbstractController
         }
 
         return $this->render('@NetBSSecure/audit/index.html.twig', [
-            'form'                  => $form->createView(),
-            'sensitive_roles'       => AccessAuditService::SENSITIVE_ROLES,
-            'sensitive_role_counts' => $this->audit->countUsersForSensitiveRoles(),
+            'form'            => $form->createView(),
+            'sensitive_roles' => AccessAuditService::SENSITIVE_ROLES,
+            'matrix'          => $this->audit->buildSensitiveRoleMatrix(),
         ]);
     }
 

--- a/netBS/core/SecureBundle/Controller/AuditController.php
+++ b/netBS/core/SecureBundle/Controller/AuditController.php
@@ -47,8 +47,9 @@ final class AuditController extends AbstractController
         }
 
         return $this->render('@NetBSSecure/audit/index.html.twig', [
-            'form'            => $form->createView(),
-            'sensitive_roles' => AccessAuditService::SENSITIVE_ROLES,
+            'form'                  => $form->createView(),
+            'sensitive_roles'       => AccessAuditService::SENSITIVE_ROLES,
+            'sensitive_role_counts' => $this->audit->countUsersForSensitiveRoles(),
         ]);
     }
 

--- a/netBS/core/SecureBundle/Controller/AuditController.php
+++ b/netBS/core/SecureBundle/Controller/AuditController.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Controller;
+
+use Doctrine\ORM\EntityManagerInterface;
+use NetBS\FichierBundle\Service\FichierConfig;
+use NetBS\SecureBundle\Service\AccessAuditService;
+use NetBS\SecureBundle\Service\SecureConfig;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\IsGranted;
+
+#[IsGranted('ROLE_ADMIN')]
+final class AuditController extends AbstractController
+{
+    public function __construct(
+        private readonly AccessAuditService $audit,
+        private readonly EntityManagerInterface $em,
+        private readonly SecureConfig $secureConfig,
+        private readonly FichierConfig $fichierConfig,
+    ) {}
+
+    #[Route('/utilisateurs/audit', name: 'netbs.secure.audit.index')]
+    public function index(): Response
+    {
+        return $this->render('@NetBSSecure/audit/index.html.twig', [
+            'sensitive_roles' => AccessAuditService::SENSITIVE_ROLES,
+        ]);
+    }
+
+    #[Route('/utilisateurs/audit/users/{id}', name: 'netbs.secure.audit.user_show')]
+    public function userShow(int $id): Response
+    {
+        $user = $this->em->find($this->secureConfig->getUserClass(), $id);
+        if (!$user) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('@NetBSSecure/audit/user_detail.html.twig', [
+            'report'          => $this->audit->auditUser($user),
+            'sensitive_roles' => AccessAuditService::SENSITIVE_ROLES,
+        ]);
+    }
+
+    #[Route('/utilisateurs/audit/scopes/groupe/{id}', name: 'netbs.secure.audit.scope_groupe')]
+    public function scopeGroupe(int $id): Response
+    {
+        $groupe = $this->em->find($this->fichierConfig->getGroupeClass(), $id);
+        if (!$groupe) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('@NetBSSecure/audit/scope_detail.html.twig', [
+            'report'          => $this->audit->auditScope($groupe),
+            'sensitive_roles' => AccessAuditService::SENSITIVE_ROLES,
+        ]);
+    }
+
+    #[Route('/utilisateurs/audit/scopes/role/{role}', name: 'netbs.secure.audit.scope_role', requirements: ['role' => 'ROLE_[A-Z_]+'])]
+    public function scopeRole(string $role): Response
+    {
+        $roleEntity = $this->em->getRepository($this->secureConfig->getRoleClass())
+            ->findOneBy(['role' => $role]);
+        if (!$roleEntity) {
+            throw $this->createNotFoundException();
+        }
+
+        return $this->render('@NetBSSecure/audit/scope_detail.html.twig', [
+            'report'          => $this->audit->auditScope($roleEntity),
+            'sensitive_roles' => AccessAuditService::SENSITIVE_ROLES,
+        ]);
+    }
+}

--- a/netBS/core/SecureBundle/Controller/AuditController.php
+++ b/netBS/core/SecureBundle/Controller/AuditController.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace NetBS\SecureBundle\Controller;
 
 use Doctrine\ORM\EntityManagerInterface;
+use NetBS\FichierBundle\Mapping\BaseGroupe;
 use NetBS\FichierBundle\Service\FichierConfig;
+use NetBS\SecureBundle\Form\AuditPickType;
+use NetBS\SecureBundle\Mapping\BaseUser;
 use NetBS\SecureBundle\Service\AccessAuditService;
 use NetBS\SecureBundle\Service\SecureConfig;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -24,9 +28,26 @@ final class AuditController extends AbstractController
     ) {}
 
     #[Route('/utilisateurs/audit', name: 'netbs.secure.audit.index')]
-    public function index(): Response
+    public function index(Request $request): Response
     {
+        $form = $this->createForm(AuditPickType::class);
+        $form->handleRequest($request);
+
+        if ($form->isSubmitted() && $form->isValid()) {
+            $data = $form->getData();
+            $user = $data['user'] ?? null;
+            $groupe = $data['groupe'] ?? null;
+
+            if ($user instanceof BaseUser) {
+                return $this->redirectToRoute('netbs.secure.audit.user_show', ['id' => $user->getId()]);
+            }
+            if ($groupe instanceof BaseGroupe) {
+                return $this->redirectToRoute('netbs.secure.audit.scope_groupe', ['id' => $groupe->getId()]);
+            }
+        }
+
         return $this->render('@NetBSSecure/audit/index.html.twig', [
+            'form'            => $form->createView(),
             'sensitive_roles' => AccessAuditService::SENSITIVE_ROLES,
         ]);
     }

--- a/netBS/core/SecureBundle/DataFixtures/LoadRolesData.php
+++ b/netBS/core/SecureBundle/DataFixtures/LoadRolesData.php
@@ -7,53 +7,31 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use NetBS\SecureBundle\Entity\Role;
-use NetBS\SecureBundle\Service\SecureConfig;
-use Symfony\Component\Yaml\Yaml;
+use NetBS\SecureBundle\Service\RoleTreeSyncer;
 
+/**
+ * Thin fixture that delegates to {@see RoleTreeSyncer}. The syncer walks
+ * every `RoleTreeSourceInterface` registered in the container, so this
+ * fixture has no role-data of its own anymore — it just calls into the
+ * shared reconciliation path that the `netbs:roles:sync` command also uses.
+ *
+ * Order 1 keeps the reference-setting step early enough for other fixtures
+ * (e.g. LoadUserData) to consume the `ROLE_ADMIN` reference.
+ */
 class LoadRolesData extends AbstractFixture implements OrderedFixtureInterface, FixtureGroupInterface
 {
-    private $secureConfig;
-
-    public function __construct(SecureConfig $config) {
-        $this->secureConfig = $config;
+    public function __construct(private readonly RoleTreeSyncer $syncer)
+    {
     }
 
     public function load(ObjectManager $manager): void
     {
-        $config = Yaml::parse(file_get_contents(__DIR__ . "/../Resources/security/system_roles.yml"));
-        $roles  = $this->loadRole($config['roles'], $manager);
+        $this->syncer->syncAll();
 
-        foreach($roles as $role)
-            $manager->persist($role);
-
-        $manager->flush();
-
-        $this->addReference('ROLE_ADMIN', $manager->getRepository(Role::class)->findOneBy(array('role' => 'ROLE_ADMIN')));
-    }
-
-    public function loadRole(array $data, ObjectManager $manager) {
-
-        $rc     = $this->secureConfig->getRoleClass();
-
-        $roles  = [];
-
-        foreach($data as $name => $params) {
-
-            $role   = new $rc($name, $params['poids'], isset($params['description']) ? $params['description'] : '');
-
-            if(isset($params['children'])) {
-
-                $childs = $this->loadRole($params['children'], $manager);
-
-                foreach($childs as $child)
-                    $role->addChild($child);
-            }
-
-            $manager->persist($role);
-            $roles[] = $role;
+        $admin = $manager->getRepository(Role::class)->findOneBy(['role' => 'ROLE_ADMIN']);
+        if ($admin !== null) {
+            $this->addReference('ROLE_ADMIN', $admin);
         }
-
-        return $roles;
     }
 
     public static function getGroups(): array

--- a/netBS/core/SecureBundle/Form/AuditPickType.php
+++ b/netBS/core/SecureBundle/Form/AuditPickType.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Form;
+
+use NetBS\CoreBundle\Form\Type\AjaxSelect2DocumentType;
+use NetBS\FichierBundle\Service\FichierConfig;
+use NetBS\SecureBundle\Service\SecureConfig;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface;
+
+final class AuditPickType extends AbstractType
+{
+    public function __construct(
+        private readonly SecureConfig $secureConfig,
+        private readonly FichierConfig $fichierConfig,
+    ) {}
+
+    public function buildForm(FormBuilderInterface $builder, array $options): void
+    {
+        $builder
+            ->add('user', AjaxSelect2DocumentType::class, [
+                'class'    => $this->secureConfig->getUserClass(),
+                'label'    => 'Utilisateur',
+                'required' => false,
+            ])
+            ->add('groupe', AjaxSelect2DocumentType::class, [
+                'class'    => $this->fichierConfig->getGroupeClass(),
+                'label'    => 'Groupe',
+                'required' => false,
+            ]);
+    }
+}

--- a/netBS/core/SecureBundle/Listener/MainMenuListener.php
+++ b/netBS/core/SecureBundle/Listener/MainMenuListener.php
@@ -46,7 +46,8 @@ class MainMenuListener
             $subMenu
                 ->addSubLink('Gestion', 'netbs.secure.user.list_users')
                 ->addSubLink('Nouveau', 'netbs.secure.user.add_user')
-                ->addSubLink('Autorisations', 'netbs.secure.autorisation.list');
+                ->addSubLink('Autorisations', 'netbs.secure.autorisation.list')
+                ->addSubLink('Audit des accès', 'netbs.secure.audit.index');
         }
     }
 }

--- a/netBS/core/SecureBundle/Resources/config/services.yml
+++ b/netBS/core/SecureBundle/Resources/config/services.yml
@@ -36,6 +36,8 @@ services:
         resource: '../../DataFixtures'
         tags: ['doctrine.fixture.orm']
 
+    NetBS\SecureBundle\Service\AccessAuditService: ~
+
     NetBS\SecureBundle\Service\UserManager: ~
 
     NetBS\SecureBundle\Service\SecureConfig:

--- a/netBS/core/SecureBundle/Resources/config/services.yml
+++ b/netBS/core/SecureBundle/Resources/config/services.yml
@@ -8,6 +8,22 @@ services:
         autowire: true
         autoconfigure: true
 
+    # Auto-tag any class implementing RoleTreeSourceInterface so RoleTreeSyncer
+    # collects them through its tagged iterator.
+    _instanceof:
+        NetBS\SecureBundle\Service\RoleTreeSourceInterface:
+            tags: ['netbs.role_tree_source']
+
+    NetBS\SecureBundle\Service\SystemRoleTreeSource: ~
+
+    NetBS\SecureBundle\Service\RoleTreeSyncer:
+        arguments:
+            $sources: !tagged_iterator netbs.role_tree_source
+
+    NetBS\SecureBundle\Command\SyncRolesCommand: ~
+
+    NetBS\SecureBundle\Command\DebugUserRolesCommand: ~
+
     NetBS\SecureBundle\Controller\:
         resource: '../../Controller'
         tags: ['controller.service_arguments']

--- a/netBS/core/SecureBundle/Resources/config/services.yml
+++ b/netBS/core/SecureBundle/Resources/config/services.yml
@@ -80,6 +80,10 @@ services:
         tags:
         - { name: form.type }
 
+    NetBS\SecureBundle\Form\AuditPickType:
+        tags:
+            - { name: form.type }
+
     NetBS\SecureBundle\Helper\UserHelper:
         tags:
             - { name: netbs.helper }

--- a/netBS/core/SecureBundle/Resources/security/system_roles.yml
+++ b/netBS/core/SecureBundle/Resources/security/system_roles.yml
@@ -3,43 +3,6 @@ roles:
         description: "Role administrateur système"
         poids: 10000000
         children:
-            ROLE_SG:
-                poids: 8000
-                description: "Role secrétaire général"
-                children:
-                    ROLE_CREATE_EVERYWHERE:
-                        poids: 5000
-                        description: "Permet de créer partout"
-                        children:
-                            ROLE_CREATE:
-                                poids: 100
-                                description: "Création dans les groupes"
-                            ROLE_CREATE_ATTRIBUTION:
-                                poids: 150
-                    ROLE_UPDATE_EVERYWHERE:
-                        poids: 5000
-                        description: "Permet de tout modifier"
-                        children:
-                            ROLE_UPDATE:
-                                poids: 100
-                                description: "Modification dans les groupes"
-                    ROLE_READ_EVERYWHERE:
-                        poids: 5000
-                        description: "Permet de tout voir"
-                        children:
-                            ROLE_READ:
-                                poids: 100
-                                description: "Visibilité partout"
-                    ROLE_DELETE_EVERYWHERE:
-                        poids: 5000
-                        description: "Permet de tout supprimer"
-                        children:
-                            ROLE_DELETE:
-                                poids: 100
-                                description: "Suppression dans les groupes"
-
-
-
-    ROLE_USER:
-        description: "Autorisation d'accès à l'application"
-        poids: 1
+            ROLE_USER:
+                description: "Autorisation d'accès à l'application"
+                poids: 1

--- a/netBS/core/SecureBundle/Resources/security/system_roles.yml
+++ b/netBS/core/SecureBundle/Resources/security/system_roles.yml
@@ -1,8 +1,8 @@
 roles:
     ROLE_ADMIN:
-        description: "Role administrateur système"
+        description: "Administrateur système. ACCÈS GLOBAL : court-circuite tous les voters CRUD du fichier, du facturation, du mailing et de l'APMBS via NetBSVoter::specialRule. Accès au tableau d'audit (/utilisateurs/audit) et à la gestion des clients OIDC. Parent de ROLE_USER."
         poids: 10000000
         children:
             ROLE_USER:
-                description: "Autorisation d'accès à l'application"
+                description: "Accès minimal à l'application. Rôle implicite pour tout utilisateur authentifié — sans lui, le firewall refuse l'accès. N'octroie aucune permission métier en lui-même."
                 poids: 1

--- a/netBS/core/SecureBundle/Resources/security/system_roles.yml
+++ b/netBS/core/SecureBundle/Resources/security/system_roles.yml
@@ -1,8 +1,8 @@
 roles:
     ROLE_ADMIN:
-        description: "Administrateur système. ACCÈS GLOBAL : court-circuite tous les voters CRUD du fichier, du facturation, du mailing et de l'APMBS via NetBSVoter::specialRule. Accès au tableau d'audit (/utilisateurs/audit) et à la gestion des clients OIDC. Parent de ROLE_USER."
+        description: "Accès complet à toute l'application, sans restriction de groupe."
         poids: 10000000
         children:
             ROLE_USER:
-                description: "Accès minimal à l'application. Rôle implicite pour tout utilisateur authentifié — sans lui, le firewall refuse l'accès. N'octroie aucune permission métier en lui-même."
+                description: "Accès minimal nécessaire pour se connecter."
                 poids: 1

--- a/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
@@ -1,0 +1,28 @@
+{# Renders one AccessGrant. Inputs: grant, sensitive_roles. #}
+<div class="list-group-item">
+    <div class="d-flex justify-content-between align-items-start">
+        <div class="me-3">
+            {% if grant.provenance.value == 'direct_role' %}
+                <span class="badge bg-primary">Rôle direct</span>
+            {% elseif grant.provenance.value == 'fonction_role' %}
+                <span class="badge bg-info">Fonction</span>
+                {% if grant.sourceFonction %}
+                    <span class="text-muted small">{{ grant.sourceFonction.nom }}</span>
+                {% endif %}
+            {% else %}
+                <span class="badge bg-warning text-dark">Autorisation</span>
+            {% endif %}
+            {% if grant.scope %}
+                <span class="ms-2 badge bg-light text-dark border">📂 {{ grant.scope.nom }}</span>
+            {% else %}
+                <span class="ms-2 badge bg-light text-dark border">Global</span>
+            {% endif %}
+        </div>
+        <div>
+            {% for role in grant.roles %}
+                {% set is_sensitive = role.role in sensitive_roles %}
+                <span class="badge {{ is_sensitive ? 'bg-danger' : 'bg-secondary' }}">{{ role.role }}</span>
+            {% endfor %}
+        </div>
+    </div>
+</div>

--- a/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
@@ -13,7 +13,7 @@
                 <span class="badge bg-warning text-dark">Autorisation</span>
             {% endif %}
             {% if grant.scope %}
-                <span class="ms-2 badge bg-light text-dark border">📂 {{ grant.scope.nom }}</span>
+                <span class="ms-2 badge bg-light text-dark border">{{ grant.scope.nom }}</span>
             {% else %}
                 <span class="ms-2 badge bg-light text-dark border">Global</span>
             {% endif %}

--- a/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
@@ -22,10 +22,16 @@
                 <span class="ms-2 badge bg-light text-dark border">Global</span>
             {% endif %}
         </div>
-        <div>
+        <div class="text-end">
             {% for role in grant.roles %}
                 {% set is_sensitive = role.role in sensitive_roles %}
-                <span class="badge {{ is_sensitive ? 'bg-danger' : 'bg-secondary' }}">{{ role.role }}</span>
+                {% set is_explicit = role.role in grant.explicitRoleNames %}
+                {% if is_explicit %}
+                    <span class="badge {{ is_sensitive ? 'bg-danger' : 'bg-secondary' }}">{{ role.role }}</span>
+                {% else %}
+                    <span class="badge {{ is_sensitive ? 'bg-danger' : 'bg-secondary' }} opacity-50"
+                          title="Hérité d'un rôle ancêtre">{{ role.role }} <small>(hérité)</small></span>
+                {% endif %}
             {% endfor %}
         </div>
     </div>

--- a/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
@@ -1,5 +1,9 @@
 {# Renders one AccessGrant. Inputs: grant, sensitive_roles. #}
-<div class="list-group-item">
+{% set has_sensitive = 0 %}
+{% for role in grant.roles %}
+    {% if role.role in sensitive_roles %}{% set has_sensitive = 1 %}{% endif %}
+{% endfor %}
+<div class="list-group-item audit-grant" data-has-sensitive="{{ has_sensitive }}">
     <div class="d-flex justify-content-between align-items-start">
         <div class="me-3">
             {% if grant.provenance.value == 'direct_role' %}

--- a/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/_grant_row.html.twig
@@ -3,36 +3,45 @@
 {% for role in grant.roles %}
     {% if role.role in sensitive_roles %}{% set has_sensitive = 1 %}{% endif %}
 {% endfor %}
+{% set explicit_roles = grant.roles|filter(r => r.role in grant.explicitRoleNames) %}
+{% set inherited_roles = grant.roles|filter(r => r.role not in grant.explicitRoleNames) %}
 <div class="list-group-item audit-grant" data-has-sensitive="{{ has_sensitive }}">
-    <div class="d-flex justify-content-between align-items-start">
-        <div class="me-3">
-            {% if grant.provenance.value == 'direct_role' %}
-                <span class="badge bg-primary">Rôle direct</span>
-            {% elseif grant.provenance.value == 'fonction_role' %}
-                <span class="badge bg-info">Fonction</span>
-                {% if grant.sourceFonction %}
-                    <span class="text-muted small">{{ grant.sourceFonction.nom }}</span>
-                {% endif %}
-            {% else %}
-                <span class="badge bg-warning text-dark">Autorisation</span>
+    <div class="mb-2">
+        {% if grant.provenance.value == 'direct_role' %}
+            <span class="badge bg-primary">Rôle direct</span>
+        {% elseif grant.provenance.value == 'fonction_role' %}
+            <span class="badge bg-info">Fonction</span>
+            {% if grant.sourceFonction %}
+                <strong class="ms-1">{{ grant.sourceFonction.nom }}</strong>
             {% endif %}
-            {% if grant.scope %}
-                <span class="ms-2 badge bg-light text-dark border">{{ grant.scope.nom }}</span>
-            {% else %}
-                <span class="ms-2 badge bg-light text-dark border">Global</span>
-            {% endif %}
-        </div>
-        <div class="text-end">
-            {% for role in grant.roles %}
-                {% set is_sensitive = role.role in sensitive_roles %}
-                {% set is_explicit = role.role in grant.explicitRoleNames %}
-                {% if is_explicit %}
+        {% else %}
+            <span class="badge bg-warning text-dark">Autorisation</span>
+        {% endif %}
+        {% if grant.scope %}
+            <span class="ms-2 text-muted small">sur</span>
+            <span class="badge bg-light text-dark border">{{ grant.scope.nom }}</span>
+        {% endif %}
+    </div>
+
+    <div class="ms-3 small">
+        {% if explicit_roles|length > 0 %}
+            <div class="mb-1">
+                <span class="text-muted me-2">Donne&nbsp;:</span>
+                {% for role in explicit_roles %}
+                    {% set is_sensitive = role.role in sensitive_roles %}
                     <span class="badge {{ is_sensitive ? 'bg-danger' : 'bg-secondary' }}">{{ role.role }}</span>
-                {% else %}
+                {% endfor %}
+            </div>
+        {% endif %}
+        {% if inherited_roles|length > 0 %}
+            <div>
+                <span class="text-muted me-2">Hérite&nbsp;:</span>
+                {% for role in inherited_roles %}
+                    {% set is_sensitive = role.role in sensitive_roles %}
                     <span class="badge {{ is_sensitive ? 'bg-danger' : 'bg-secondary' }} opacity-50"
-                          title="Hérité d'un rôle ancêtre">{{ role.role }} <small>(hérité)</small></span>
-                {% endif %}
-            {% endfor %}
-        </div>
+                          title="Hérité d'un rôle ancêtre">{{ role.role }}</span>
+                {% endfor %}
+            </div>
+        {% endif %}
     </div>
 </div>

--- a/netBS/core/SecureBundle/Resources/views/audit/_sensitive_toggle.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/_sensitive_toggle.html.twig
@@ -1,0 +1,20 @@
+{# Sensitive-only filter switch. Pair with a wrapper id="auditGrants" containing
+   .audit-grant rows that carry a data-has-sensitive="0|1" attribute. #}
+<div class="form-check form-switch m-0">
+    <input class="form-check-input" type="checkbox" id="auditSensitiveOnly">
+    <label class="form-check-label small" for="auditSensitiveOnly">Afficher uniquement les rôles sensibles</label>
+</div>
+<style>
+    #auditGrants.audit-sensitive-only .audit-grant[data-has-sensitive="0"] { display: none; }
+</style>
+<script>
+    (function () {
+        const toggle = document.getElementById('auditSensitiveOnly');
+        const grants = document.getElementById('auditGrants');
+        if (toggle && grants) {
+            toggle.addEventListener('change', () => {
+                grants.classList.toggle('audit-sensitive-only', toggle.checked);
+            });
+        }
+    })();
+</script>

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -30,22 +30,21 @@
         </div>
 
         <h5 class="mb-2">Rôles sensibles</h5>
-        <p class="text-muted small mb-3">Utilisateurs ayant effectivement accès via chaque rôle. <strong>Explicite</strong>&nbsp;: le rôle est listé directement, par fonction ou par autorisation. <strong>Hérité</strong>&nbsp;: obtenu via un rôle ancêtre (typiquement ROLE_ADMIN).</p>
-        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 mb-3">
+        <div class="row row-cols-2 row-cols-md-3 row-cols-lg-6 g-2 mb-3">
             {% for role in sensitive_roles %}
                 {% set explicit = matrix.counts.explicit[role] ?? 0 %}
                 {% set inherited = matrix.counts.inherited[role] ?? 0 %}
+                {% set has_any = explicit > 0 or inherited > 0 %}
                 <div class="col">
                     <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
-                       class="card text-decoration-none h-100 {{ explicit > 0 ? 'border-danger' : '' }}">
-                        <div class="card-body">
-                            <div class="text-muted small">{{ role }}</div>
-                            <div class="d-flex align-items-baseline gap-3">
-                                <span class="h4 mb-0 {{ explicit > 0 ? 'text-danger' : 'text-muted' }}">{{ explicit }}</span>
-                                <span class="small text-muted">explicite{% if explicit != 1 %}s{% endif %}</span>
-                                <span class="text-muted">·</span>
-                                <span class="h6 mb-0 text-muted">{{ inherited }}</span>
-                                <span class="small text-muted">hérité{% if inherited != 1 %}s{% endif %}</span>
+                       class="card text-decoration-none h-100 {{ has_any ? 'border-danger' : '' }}">
+                        <div class="card-body py-2 px-3">
+                            <div class="text-muted small text-truncate">{{ role|replace({'ROLE_': ''}) }}</div>
+                            <div class="text-danger">
+                                <span class="h5 mb-0">{{ explicit }}</span>
+                                <span class="small">·</span>
+                                <span class="h6 mb-0">{{ inherited }}</span>
+                                <span class="small">hérité{% if inherited != 1 %}s{% endif %}</span>
                             </div>
                         </div>
                     </a>
@@ -90,11 +89,7 @@
                                                     {# Aggregate provenances of grants that hold the role explicitly. #}
                                                     {% set provs = [] %}
                                                     {% for g in cell.grants %}
-                                                        {% set holds_role_explicit = false %}
-                                                        {% for r in g.roles %}
-                                                            {% if r.role == role %}{% set holds_role_explicit = true %}{% endif %}
-                                                        {% endfor %}
-                                                        {% if holds_role_explicit %}
+                                                        {% if role in g.explicitRoleNames %}
                                                             {% set letter = g.provenance.value == 'direct_role' ? 'D'
                                                                            : g.provenance.value == 'fonction_role' ? 'F' : 'A' %}
                                                             {% if letter not in provs %}{% set provs = provs|merge([letter]) %}{% endif %}
@@ -102,7 +97,7 @@
                                                     {% endfor %}
                                                     <span class="badge bg-danger" title="Explicite — {{ provs|join(' + ') }}">{{ provs|join('') }}</span>
                                                 {% else %}
-                                                    <span class="badge bg-secondary opacity-75" title="Hérité d'un rôle ancêtre">I</span>
+                                                    <span class="badge bg-danger opacity-50" title="Hérité d'un rôle ancêtre">hérité</span>
                                                 {% endif %}
                                             </td>
                                         {% endfor %}
@@ -115,7 +110,7 @@
                         Légende&nbsp;: <span class="badge bg-danger">D</span> rôle direct ·
                         <span class="badge bg-danger">F</span> via fonction ·
                         <span class="badge bg-danger">A</span> via autorisation ·
-                        <span class="badge bg-secondary opacity-75">I</span> hérité (ancêtre)
+                        <span class="badge bg-danger opacity-50">hérité</span> via un rôle ancêtre
                     </div>
                 {% endif %}
             </div>

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -40,11 +40,10 @@
                        class="card text-decoration-none h-100 {{ has_any ? 'border-danger' : '' }}">
                         <div class="card-body py-2 px-3">
                             <div class="text-muted small text-truncate">{{ role|replace({'ROLE_': ''}) }}</div>
-                            <div class="text-danger">
-                                <span class="h5 mb-0">{{ explicit }}</span>
-                                <span class="small">·</span>
-                                <span class="h6 mb-0">{{ inherited }}</span>
-                                <span class="small">hérité{% if inherited != 1 %}s{% endif %}</span>
+                            <div class="text-danger d-flex align-items-baseline gap-2">
+                                <span class="h3 fw-bold mb-0">{{ explicit }}</span>
+                                <span>·</span>
+                                <span class="h4 fw-bold mb-0">{{ inherited }}</span>
                             </div>
                         </div>
                     </a>

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -29,11 +29,21 @@
             </div>
         </div>
 
+        {# Per-role counts derived from the matrix #}
+        {% set role_counts = {} %}
+        {% for role in sensitive_roles %}
+            {% set c = 0 %}
+            {% for row in matrix.rows %}
+                {% if row.cells[role] is defined %}{% set c = c + 1 %}{% endif %}
+            {% endfor %}
+            {% set role_counts = role_counts|merge({(role): c}) %}
+        {% endfor %}
+
         <h5 class="mb-2">Rôles sensibles</h5>
         <p class="text-muted small mb-3">Nombre d'utilisateurs ayant effectivement accès via chaque rôle. Cliquer pour voir le détail.</p>
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 mb-3">
             {% for role in sensitive_roles %}
-                {% set count = sensitive_role_counts[role] ?? 0 %}
+                {% set count = role_counts[role] %}
                 <div class="col">
                     <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
                        class="card text-decoration-none h-100 {{ count > 0 ? 'border-danger' : '' }}">
@@ -48,6 +58,65 @@
                     </a>
                 </div>
             {% endfor %}
+        </div>
+
+        <div class="card">
+            <div class="card-header"><strong>Matrice des accès sensibles</strong>
+                <span class="text-muted small">— {{ matrix.rows|length }} utilisateur{% if matrix.rows|length != 1 %}s{% endif %}</span>
+            </div>
+            <div class="card-body p-0">
+                {% if matrix.rows is empty %}
+                    <div class="alert alert-info m-3 mb-0">Aucun utilisateur n'a de rôle sensible.</div>
+                {% else %}
+                    <div class="table-responsive">
+                        <table class="table table-sm table-hover align-middle mb-0">
+                            <thead>
+                                <tr>
+                                    <th scope="col" class="ps-3">Utilisateur</th>
+                                    {% for role in matrix.roles %}
+                                        <th scope="col" class="text-center">
+                                            <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
+                                               class="text-decoration-none text-reset small">{{ role|replace({'ROLE_': ''}) }}</a>
+                                        </th>
+                                    {% endfor %}
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for row in matrix.rows %}
+                                    <tr>
+                                        <th scope="row" class="ps-3 fw-normal">
+                                            <a href="{{ path('netbs.secure.audit.user_show', {id: row.user.id}) }}"
+                                               class="text-decoration-none">{{ row.user.username }}</a>
+                                        </th>
+                                        {% for role in matrix.roles %}
+                                            {% set grants = row.cells[role]|default([]) %}
+                                            <td class="text-center">
+                                                {% if grants is not empty %}
+                                                    {# Provenance hint: D (direct), F (fonction), A (autorisation). #}
+                                                    {% set provs = [] %}
+                                                    {% for g in grants %}
+                                                        {% set letter = g.provenance.value == 'direct_role' ? 'D'
+                                                                       : g.provenance.value == 'fonction_role' ? 'F' : 'A' %}
+                                                        {% if letter not in provs %}{% set provs = provs|merge([letter]) %}{% endif %}
+                                                    {% endfor %}
+                                                    <span class="badge bg-danger" title="{{ provs|join(' + ') }}">{{ provs|join('') }}</span>
+                                                {% else %}
+                                                    <span class="text-muted">·</span>
+                                                {% endif %}
+                                            </td>
+                                        {% endfor %}
+                                    </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    </div>
+                    <div class="card-footer small text-muted">
+                        Légende&nbsp;: <span class="badge bg-danger">D</span> rôle direct ·
+                        <span class="badge bg-danger">F</span> via fonction ·
+                        <span class="badge bg-danger">A</span> via autorisation
+                    </div>
+                {% endif %}
+            </div>
         </div>
 
     </div>

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -42,8 +42,7 @@
                             <div class="text-muted small text-truncate">{{ role|replace({'ROLE_': ''}) }}</div>
                             <div class="text-danger d-flex align-items-baseline gap-2">
                                 <span class="h3 fw-bold mb-0">{{ explicit }}</span>
-                                <span>·</span>
-                                <span class="h4 fw-bold mb-0">{{ inherited }}</span>
+                                <span class="h4 fw-bold mb-0">({{ inherited }})</span>
                             </div>
                         </div>
                     </a>

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -30,19 +30,22 @@
         </div>
 
         <h5 class="mb-2">Rôles sensibles</h5>
-        <p class="text-muted small mb-3">Nombre d'utilisateurs ayant effectivement accès via chaque rôle. Cliquer pour voir le détail.</p>
+        <p class="text-muted small mb-3">Utilisateurs ayant effectivement accès via chaque rôle. <strong>Explicite</strong>&nbsp;: le rôle est listé directement, par fonction ou par autorisation. <strong>Hérité</strong>&nbsp;: obtenu via un rôle ancêtre (typiquement ROLE_ADMIN).</p>
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 mb-3">
             {% for role in sensitive_roles %}
-                {% set count = matrix.counts[role] ?? 0 %}
+                {% set explicit = matrix.counts.explicit[role] ?? 0 %}
+                {% set inherited = matrix.counts.inherited[role] ?? 0 %}
                 <div class="col">
                     <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
-                       class="card text-decoration-none h-100 {{ count > 0 ? 'border-danger' : '' }}">
-                        <div class="card-body d-flex justify-content-between align-items-center">
-                            <div>
-                                <div class="text-muted small">{{ role }}</div>
-                                <div class="h4 mb-0 {{ count > 0 ? 'text-danger' : 'text-muted' }}">
-                                    {{ count }} <span class="small fw-normal">utilisateur{% if count != 1 %}s{% endif %}</span>
-                                </div>
+                       class="card text-decoration-none h-100 {{ explicit > 0 ? 'border-danger' : '' }}">
+                        <div class="card-body">
+                            <div class="text-muted small">{{ role }}</div>
+                            <div class="d-flex align-items-baseline gap-3">
+                                <span class="h4 mb-0 {{ explicit > 0 ? 'text-danger' : 'text-muted' }}">{{ explicit }}</span>
+                                <span class="small text-muted">explicite{% if explicit != 1 %}s{% endif %}</span>
+                                <span class="text-muted">·</span>
+                                <span class="h6 mb-0 text-muted">{{ inherited }}</span>
+                                <span class="small text-muted">hérité{% if inherited != 1 %}s{% endif %}</span>
                             </div>
                         </div>
                     </a>
@@ -79,19 +82,27 @@
                                                class="text-decoration-none">{{ row.user.username }}</a>
                                         </th>
                                         {% for role in matrix.roles %}
-                                            {% set grants = row.cells[role]|default([]) %}
+                                            {% set cell = row.cells[role]|default(null) %}
                                             <td class="text-center">
-                                                {% if grants is not empty %}
-                                                    {# Provenance hint: D (direct), F (fonction), A (autorisation). #}
-                                                    {% set provs = [] %}
-                                                    {% for g in grants %}
-                                                        {% set letter = g.provenance.value == 'direct_role' ? 'D'
-                                                                       : g.provenance.value == 'fonction_role' ? 'F' : 'A' %}
-                                                        {% if letter not in provs %}{% set provs = provs|merge([letter]) %}{% endif %}
-                                                    {% endfor %}
-                                                    <span class="badge bg-danger" title="{{ provs|join(' + ') }}">{{ provs|join('') }}</span>
-                                                {% else %}
+                                                {% if cell is null %}
                                                     <span class="text-muted">·</span>
+                                                {% elseif cell.explicit %}
+                                                    {# Aggregate provenances of grants that hold the role explicitly. #}
+                                                    {% set provs = [] %}
+                                                    {% for g in cell.grants %}
+                                                        {% set holds_role_explicit = false %}
+                                                        {% for r in g.roles %}
+                                                            {% if r.role == role %}{% set holds_role_explicit = true %}{% endif %}
+                                                        {% endfor %}
+                                                        {% if holds_role_explicit %}
+                                                            {% set letter = g.provenance.value == 'direct_role' ? 'D'
+                                                                           : g.provenance.value == 'fonction_role' ? 'F' : 'A' %}
+                                                            {% if letter not in provs %}{% set provs = provs|merge([letter]) %}{% endif %}
+                                                        {% endif %}
+                                                    {% endfor %}
+                                                    <span class="badge bg-danger" title="Explicite — {{ provs|join(' + ') }}">{{ provs|join('') }}</span>
+                                                {% else %}
+                                                    <span class="badge bg-secondary opacity-75" title="Hérité d'un rôle ancêtre">I</span>
                                                 {% endif %}
                                             </td>
                                         {% endfor %}
@@ -103,7 +114,8 @@
                     <div class="card-footer small text-muted">
                         Légende&nbsp;: <span class="badge bg-danger">D</span> rôle direct ·
                         <span class="badge bg-danger">F</span> via fonction ·
-                        <span class="badge bg-danger">A</span> via autorisation
+                        <span class="badge bg-danger">A</span> via autorisation ·
+                        <span class="badge bg-secondary opacity-75">I</span> hérité (ancêtre)
                     </div>
                 {% endif %}
             </div>

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -1,0 +1,49 @@
+{% extends '@NetBSCore/layout/backend.layout.twig' %}
+
+{% block title %}Audit des accès{% endblock %}
+
+{% block main %}
+    <div class="container-fluid">
+
+        {% include '@NetBSCore/includes/header.include.twig' with {
+            header: "Audit des accès",
+            subHeader: "Contrôler les droits attribués aux utilisateurs"
+        } %}
+
+        <div class="row">
+            <div class="col-md-6">
+                <div class="card mb-3">
+                    <div class="card-header"><strong>Utilisateurs</strong></div>
+                    <div class="card-body">
+                        <p class="text-muted mb-2">Pour auditer un utilisateur, ouvrez "Utilisateurs &gt; Gestion", puis utilisez le bouton "Audit" sur la fiche.</p>
+                        <a href="{{ path('netbs.secure.user.list_users') }}" class="btn btn-sm btn-outline-primary">Liste des utilisateurs</a>
+                    </div>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="card mb-3">
+                    <div class="card-header"><strong>Rôles sensibles</strong></div>
+                    <div class="card-body">
+                        <p class="text-muted">Voir tous les utilisateurs ayant accès via un rôle sensible.</p>
+                        <ul class="list-inline mb-0">
+                            {% for role in sensitive_roles %}
+                                <li class="list-inline-item mb-1">
+                                    <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
+                                       class="badge bg-danger text-decoration-none">{{ role }}</a>
+                                </li>
+                            {% endfor %}
+                        </ul>
+                    </div>
+                </div>
+                <div class="card">
+                    <div class="card-header"><strong>Groupes</strong></div>
+                    <div class="card-body">
+                        <p class="text-muted">Voir tous les utilisateurs ayant accès à un groupe (fonctions + autorisations, incluant les groupes parents).</p>
+                        <a href="{{ path('netbs.fichier.groupe.page_groupes_hierarchy') }}" class="btn btn-sm btn-outline-primary">Choisir un groupe…</a>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+    </div>
+{% endblock %}

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -10,38 +10,37 @@
             subHeader: "Contrôler les droits attribués aux utilisateurs"
         } %}
 
-        <div class="row">
-            <div class="col-md-6">
-                <div class="card mb-3">
-                    <div class="card-header"><strong>Utilisateurs</strong></div>
-                    <div class="card-body">
-                        <p class="text-muted mb-2">Pour auditer un utilisateur, ouvrez "Utilisateurs &gt; Gestion", puis utilisez le bouton "Audit" sur la fiche.</p>
-                        <a href="{{ path('netbs.secure.user.list_users') }}" class="btn btn-sm btn-outline-primary">Liste des utilisateurs</a>
+        <div class="card mb-3">
+            <div class="card-header"><strong>Sélectionner une cible à auditer</strong></div>
+            <div class="card-body">
+                {{ form_start(form) }}
+                <div class="row">
+                    <div class="col-md-6">
+                        <p class="text-muted small mb-2">Auditer un utilisateur — tous ses rôles, fonctions et autorisations.</p>
+                        {{ form_row(form.user) }}
+                    </div>
+                    <div class="col-md-6">
+                        <p class="text-muted small mb-2">Auditer un groupe — tous les utilisateurs qui y ont accès (parents inclus).</p>
+                        {{ form_row(form.groupe) }}
                     </div>
                 </div>
+                <button type="submit" class="btn btn-primary">Auditer</button>
+                {{ form_end(form) }}
             </div>
-            <div class="col-md-6">
-                <div class="card mb-3">
-                    <div class="card-header"><strong>Rôles sensibles</strong></div>
-                    <div class="card-body">
-                        <p class="text-muted">Voir tous les utilisateurs ayant accès via un rôle sensible.</p>
-                        <ul class="list-inline mb-0">
-                            {% for role in sensitive_roles %}
-                                <li class="list-inline-item mb-1">
-                                    <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
-                                       class="badge bg-danger text-decoration-none">{{ role }}</a>
-                                </li>
-                            {% endfor %}
-                        </ul>
-                    </div>
-                </div>
-                <div class="card">
-                    <div class="card-header"><strong>Groupes</strong></div>
-                    <div class="card-body">
-                        <p class="text-muted">Voir tous les utilisateurs ayant accès à un groupe (fonctions + autorisations, incluant les groupes parents).</p>
-                        <a href="{{ path('netbs.fichier.groupe.page_groupes_hierarchy') }}" class="btn btn-sm btn-outline-primary">Choisir un groupe…</a>
-                    </div>
-                </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header"><strong>Rôles sensibles</strong></div>
+            <div class="card-body">
+                <p class="text-muted">Voir tous les utilisateurs ayant accès via un rôle sensible.</p>
+                <ul class="list-inline mb-0">
+                    {% for role in sensitive_roles %}
+                        <li class="list-inline-item mb-1">
+                            <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
+                               class="badge bg-danger text-decoration-none">{{ role }}</a>
+                        </li>
+                    {% endfor %}
+                </ul>
             </div>
         </div>
 

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -29,21 +29,11 @@
             </div>
         </div>
 
-        {# Per-role counts derived from the matrix #}
-        {% set role_counts = {} %}
-        {% for role in sensitive_roles %}
-            {% set c = 0 %}
-            {% for row in matrix.rows %}
-                {% if row.cells[role] is defined %}{% set c = c + 1 %}{% endif %}
-            {% endfor %}
-            {% set role_counts = role_counts|merge({(role): c}) %}
-        {% endfor %}
-
         <h5 class="mb-2">Rôles sensibles</h5>
         <p class="text-muted small mb-3">Nombre d'utilisateurs ayant effectivement accès via chaque rôle. Cliquer pour voir le détail.</p>
         <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 mb-3">
             {% for role in sensitive_roles %}
-                {% set count = role_counts[role] %}
+                {% set count = matrix.counts[role] ?? 0 %}
                 <div class="col">
                     <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
                        class="card text-decoration-none h-100 {{ count > 0 ? 'border-danger' : '' }}">

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -29,19 +29,25 @@
             </div>
         </div>
 
-        <div class="card">
-            <div class="card-header"><strong>Rôles sensibles</strong></div>
-            <div class="card-body">
-                <p class="text-muted">Voir tous les utilisateurs ayant accès via un rôle sensible.</p>
-                <ul class="list-inline mb-0">
-                    {% for role in sensitive_roles %}
-                        <li class="list-inline-item mb-1">
-                            <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
-                               class="badge bg-danger text-decoration-none">{{ role }}</a>
-                        </li>
-                    {% endfor %}
-                </ul>
-            </div>
+        <h5 class="mb-2">Rôles sensibles</h5>
+        <p class="text-muted small mb-3">Nombre d'utilisateurs ayant effectivement accès via chaque rôle. Cliquer pour voir le détail.</p>
+        <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 g-3 mb-3">
+            {% for role in sensitive_roles %}
+                {% set count = sensitive_role_counts[role] ?? 0 %}
+                <div class="col">
+                    <a href="{{ path('netbs.secure.audit.scope_role', {role: role}) }}"
+                       class="card text-decoration-none h-100 {{ count > 0 ? 'border-danger' : '' }}">
+                        <div class="card-body d-flex justify-content-between align-items-center">
+                            <div>
+                                <div class="text-muted small">{{ role }}</div>
+                                <div class="h4 mb-0 {{ count > 0 ? 'text-danger' : 'text-muted' }}">
+                                    {{ count }} <span class="small fw-normal">utilisateur{% if count != 1 %}s{% endif %}</span>
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div>
+            {% endfor %}
         </div>
 
     </div>

--- a/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/index.html.twig
@@ -96,7 +96,7 @@
                                                     {% endfor %}
                                                     <span class="badge bg-danger" title="Explicite — {{ provs|join(' + ') }}">{{ provs|join('') }}</span>
                                                 {% else %}
-                                                    <span class="badge bg-danger opacity-50" title="Hérité d'un rôle ancêtre">hérité</span>
+                                                    <span class="badge bg-danger" title="Hérité d'un rôle ancêtre">I</span>
                                                 {% endif %}
                                             </td>
                                         {% endfor %}
@@ -109,7 +109,7 @@
                         Légende&nbsp;: <span class="badge bg-danger">D</span> rôle direct ·
                         <span class="badge bg-danger">F</span> via fonction ·
                         <span class="badge bg-danger">A</span> via autorisation ·
-                        <span class="badge bg-danger opacity-50">hérité</span> via un rôle ancêtre
+                        <span class="badge bg-danger">I</span> hérité
                     </div>
                 {% endif %}
             </div>

--- a/netBS/core/SecureBundle/Resources/views/audit/scope_detail.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/scope_detail.html.twig
@@ -1,0 +1,48 @@
+{% extends '@NetBSCore/layout/backend.layout.twig' %}
+
+{% block title %}Audit — périmètre{% endblock %}
+
+{% block main %}
+    <div class="container-fluid">
+
+        {% include '@NetBSCore/includes/header.include.twig' with {
+            header: "Audit — périmètre",
+            subHeader: "Utilisateurs ayant accès à ce périmètre"
+        } %}
+
+        <div class="card mb-3">
+            <div class="card-header">
+                <strong>
+                    {% if report.scope.nom is defined %}
+                        Groupe : {{ report.scope.nom }}
+                    {% else %}
+                        Rôle : {{ report.scope.role }}
+                    {% endif %}
+                </strong>
+                <a href="{{ path('netbs.secure.audit.index') }}" class="float-end btn btn-sm btn-link">← retour</a>
+            </div>
+            <div class="card-body">
+                <span class="badge bg-info">{{ report.entries|length }} utilisateur{% if report.entries|length != 1 %}s{% endif %}</span>
+            </div>
+        </div>
+
+        {% for entry in report.entries %}
+            <div class="card mb-2">
+                <div class="card-header">
+                    <a href="{{ path('netbs.secure.audit.user_show', {id: entry.user.id}) }}">
+                        {{ entry.user.username }}
+                    </a>
+                    <span class="text-muted small">— {{ entry.grants|length }} accès</span>
+                </div>
+                <div class="list-group list-group-flush">
+                    {% for grant in entry.grants %}
+                        {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
+                    {% endfor %}
+                </div>
+            </div>
+        {% else %}
+            <div class="alert alert-info">Aucun utilisateur n'a accès à ce périmètre.</div>
+        {% endfor %}
+
+    </div>
+{% endblock %}

--- a/netBS/core/SecureBundle/Resources/views/audit/scope_detail.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/scope_detail.html.twig
@@ -21,28 +21,49 @@
                 </strong>
                 <a href="{{ path('netbs.secure.audit.index') }}" class="float-end btn btn-sm btn-link">← retour</a>
             </div>
-            <div class="card-body">
+            <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
                 <span class="badge bg-info">{{ report.entries|length }} utilisateur{% if report.entries|length != 1 %}s{% endif %}</span>
+                <div class="form-check form-switch m-0">
+                    <input class="form-check-input" type="checkbox" id="auditSensitiveOnly">
+                    <label class="form-check-label small" for="auditSensitiveOnly">Afficher uniquement les rôles sensibles</label>
+                </div>
             </div>
         </div>
 
-        {% for entry in report.entries %}
-            <div class="card mb-2">
-                <div class="card-header">
-                    <a href="{{ path('netbs.secure.audit.user_show', {id: entry.user.id}) }}">
-                        {{ entry.user.username }}
-                    </a>
-                    <span class="text-muted small">— {{ entry.grants|length }} accès</span>
+        <div id="auditGrants">
+            {% for entry in report.entries %}
+                <div class="card mb-2">
+                    <div class="card-header">
+                        <a href="{{ path('netbs.secure.audit.user_show', {id: entry.user.id}) }}">
+                            {{ entry.user.username }}
+                        </a>
+                        <span class="text-muted small">— {{ entry.grants|length }} accès</span>
+                    </div>
+                    <div class="list-group list-group-flush">
+                        {% for grant in entry.grants %}
+                            {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
+                        {% endfor %}
+                    </div>
                 </div>
-                <div class="list-group list-group-flush">
-                    {% for grant in entry.grants %}
-                        {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
-                    {% endfor %}
-                </div>
-            </div>
-        {% else %}
-            <div class="alert alert-info">Aucun utilisateur n'a accès à ce périmètre.</div>
-        {% endfor %}
+            {% else %}
+                <div class="alert alert-info">Aucun utilisateur n'a accès à ce périmètre.</div>
+            {% endfor %}
+        </div>
+
+        <style>
+            #auditGrants.audit-sensitive-only .audit-grant[data-has-sensitive="0"] { display: none; }
+        </style>
+        <script>
+            (function () {
+                const toggle = document.getElementById('auditSensitiveOnly');
+                const grants = document.getElementById('auditGrants');
+                if (toggle && grants) {
+                    toggle.addEventListener('change', () => {
+                        grants.classList.toggle('audit-sensitive-only', toggle.checked);
+                    });
+                }
+            })();
+        </script>
 
     </div>
 {% endblock %}

--- a/netBS/core/SecureBundle/Resources/views/audit/scope_detail.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/scope_detail.html.twig
@@ -23,10 +23,7 @@
             </div>
             <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
                 <span class="badge bg-info">{{ report.entries|length }} utilisateur{% if report.entries|length != 1 %}s{% endif %}</span>
-                <div class="form-check form-switch m-0">
-                    <input class="form-check-input" type="checkbox" id="auditSensitiveOnly">
-                    <label class="form-check-label small" for="auditSensitiveOnly">Afficher uniquement les rôles sensibles</label>
-                </div>
+                {% include '@NetBSSecure/audit/_sensitive_toggle.html.twig' %}
             </div>
         </div>
 
@@ -49,21 +46,6 @@
                 <div class="alert alert-info">Aucun utilisateur n'a accès à ce périmètre.</div>
             {% endfor %}
         </div>
-
-        <style>
-            #auditGrants.audit-sensitive-only .audit-grant[data-has-sensitive="0"] { display: none; }
-        </style>
-        <script>
-            (function () {
-                const toggle = document.getElementById('auditSensitiveOnly');
-                const grants = document.getElementById('auditGrants');
-                if (toggle && grants) {
-                    toggle.addEventListener('change', () => {
-                        grants.classList.toggle('audit-sensitive-only', toggle.checked);
-                    });
-                }
-            })();
-        </script>
 
     </div>
 {% endblock %}

--- a/netBS/core/SecureBundle/Resources/views/audit/user_detail.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/user_detail.html.twig
@@ -1,0 +1,43 @@
+{% extends '@NetBSCore/layout/backend.layout.twig' %}
+
+{% block title %}Audit — {{ report.user.username }}{% endblock %}
+
+{% block main %}
+    <div class="container-fluid">
+
+        {% include '@NetBSCore/includes/header.include.twig' with {
+            header: "Audit — " ~ report.user.username,
+            subHeader: "Droits effectifs de cet utilisateur"
+        } %}
+
+        <div class="card mb-3">
+            <div class="card-header">
+                <strong>{{ report.user.username }}</strong>
+                <a href="{{ path('netbs.secure.audit.index') }}" class="float-end btn btn-sm btn-link">← retour</a>
+            </div>
+            <div class="card-body">
+                {% set sensitive_count = 0 %}
+                {% set scope_ids = [] %}
+                {% for g in report.grants %}
+                    {% for r in g.roles %}
+                        {% if r.role in sensitive_roles %}{% set sensitive_count = sensitive_count + 1 %}{% endif %}
+                    {% endfor %}
+                    {% if g.scope and g.scope.id not in scope_ids %}
+                        {% set scope_ids = scope_ids|merge([g.scope.id]) %}
+                    {% endif %}
+                {% endfor %}
+                <span class="badge bg-danger me-2">{{ sensitive_count }} rôle{% if sensitive_count != 1 %}s{% endif %} sensible{% if sensitive_count != 1 %}s{% endif %}</span>
+                <span class="badge bg-info">{{ scope_ids|length }} périmètre{% if scope_ids|length != 1 %}s{% endif %}</span>
+            </div>
+        </div>
+
+        <div class="list-group">
+            {% for grant in report.grants %}
+                {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
+            {% else %}
+                <div class="alert alert-info">Aucun accès enregistré.</div>
+            {% endfor %}
+        </div>
+
+    </div>
+{% endblock %}

--- a/netBS/core/SecureBundle/Resources/views/audit/user_detail.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/user_detail.html.twig
@@ -10,34 +10,85 @@
             subHeader: "Droits effectifs de cet utilisateur"
         } %}
 
+        {% set sensitive_count = 0 %}
+        {% set scope_ids = [] %}
+        {% for g in report.grants %}
+            {% for r in g.roles %}
+                {% if r.role in sensitive_roles %}{% set sensitive_count = sensitive_count + 1 %}{% endif %}
+            {% endfor %}
+            {% if g.scope and g.scope.id not in scope_ids %}
+                {% set scope_ids = scope_ids|merge([g.scope.id]) %}
+            {% endif %}
+        {% endfor %}
+
+        {% set direct_grants = report.grants|filter(g => g.provenance.value == 'direct_role') %}
+        {% set fonction_grants = report.grants|filter(g => g.provenance.value == 'fonction_role') %}
+        {% set autorisation_grants = report.grants|filter(g => g.provenance.value == 'autorisation') %}
+
         <div class="card mb-3">
             <div class="card-header">
                 <strong>{{ report.user.username }}</strong>
                 <a href="{{ path('netbs.secure.audit.index') }}" class="float-end btn btn-sm btn-link">← retour</a>
             </div>
-            <div class="card-body">
-                {% set sensitive_count = 0 %}
-                {% set scope_ids = [] %}
-                {% for g in report.grants %}
-                    {% for r in g.roles %}
-                        {% if r.role in sensitive_roles %}{% set sensitive_count = sensitive_count + 1 %}{% endif %}
-                    {% endfor %}
-                    {% if g.scope and g.scope.id not in scope_ids %}
-                        {% set scope_ids = scope_ids|merge([g.scope.id]) %}
-                    {% endif %}
-                {% endfor %}
-                <span class="badge bg-danger me-2">{{ sensitive_count }} rôle{% if sensitive_count != 1 %}s{% endif %} sensible{% if sensitive_count != 1 %}s{% endif %}</span>
-                <span class="badge bg-info">{{ scope_ids|length }} périmètre{% if scope_ids|length != 1 %}s{% endif %}</span>
+            <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
+                <div>
+                    <span class="badge bg-danger me-2">{{ sensitive_count }} rôle{% if sensitive_count != 1 %}s{% endif %} sensible{% if sensitive_count != 1 %}s{% endif %}</span>
+                    <span class="badge bg-info">{{ scope_ids|length }} périmètre{% if scope_ids|length != 1 %}s{% endif %}</span>
+                </div>
+                <div class="form-check form-switch m-0">
+                    <input class="form-check-input" type="checkbox" id="auditSensitiveOnly">
+                    <label class="form-check-label small" for="auditSensitiveOnly">Afficher uniquement les rôles sensibles</label>
+                </div>
             </div>
         </div>
 
-        <div class="list-group">
-            {% for grant in report.grants %}
-                {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
-            {% else %}
+        <div id="auditGrants">
+            {% if report.grants is empty %}
                 <div class="alert alert-info">Aucun accès enregistré.</div>
-            {% endfor %}
+            {% endif %}
+
+            {% if direct_grants is not empty %}
+                <h6 class="text-muted mt-3 mb-2">Rôles directs</h6>
+                <div class="list-group mb-3">
+                    {% for grant in direct_grants %}
+                        {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+
+            {% if fonction_grants is not empty %}
+                <h6 class="text-muted mt-3 mb-2">Fonctions ({{ fonction_grants|length }})</h6>
+                <div class="list-group mb-3">
+                    {% for grant in fonction_grants %}
+                        {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
+                    {% endfor %}
+                </div>
+            {% endif %}
+
+            {% if autorisation_grants is not empty %}
+                <h6 class="text-muted mt-3 mb-2">Autorisations ({{ autorisation_grants|length }})</h6>
+                <div class="list-group mb-3">
+                    {% for grant in autorisation_grants %}
+                        {% include '@NetBSSecure/audit/_grant_row.html.twig' with {grant: grant, sensitive_roles: sensitive_roles} only %}
+                    {% endfor %}
+                </div>
+            {% endif %}
         </div>
+
+        <style>
+            #auditGrants.audit-sensitive-only .audit-grant[data-has-sensitive="0"] { display: none; }
+        </style>
+        <script>
+            (function () {
+                const toggle = document.getElementById('auditSensitiveOnly');
+                const grants = document.getElementById('auditGrants');
+                if (toggle && grants) {
+                    toggle.addEventListener('change', () => {
+                        grants.classList.toggle('audit-sensitive-only', toggle.checked);
+                    });
+                }
+            })();
+        </script>
 
     </div>
 {% endblock %}

--- a/netBS/core/SecureBundle/Resources/views/audit/user_detail.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/audit/user_detail.html.twig
@@ -10,17 +10,6 @@
             subHeader: "Droits effectifs de cet utilisateur"
         } %}
 
-        {% set sensitive_count = 0 %}
-        {% set scope_ids = [] %}
-        {% for g in report.grants %}
-            {% for r in g.roles %}
-                {% if r.role in sensitive_roles %}{% set sensitive_count = sensitive_count + 1 %}{% endif %}
-            {% endfor %}
-            {% if g.scope and g.scope.id not in scope_ids %}
-                {% set scope_ids = scope_ids|merge([g.scope.id]) %}
-            {% endif %}
-        {% endfor %}
-
         {% set direct_grants = report.grants|filter(g => g.provenance.value == 'direct_role') %}
         {% set fonction_grants = report.grants|filter(g => g.provenance.value == 'fonction_role') %}
         {% set autorisation_grants = report.grants|filter(g => g.provenance.value == 'autorisation') %}
@@ -32,13 +21,10 @@
             </div>
             <div class="card-body d-flex flex-wrap justify-content-between align-items-center gap-2">
                 <div>
-                    <span class="badge bg-danger me-2">{{ sensitive_count }} rôle{% if sensitive_count != 1 %}s{% endif %} sensible{% if sensitive_count != 1 %}s{% endif %}</span>
-                    <span class="badge bg-info">{{ scope_ids|length }} périmètre{% if scope_ids|length != 1 %}s{% endif %}</span>
+                    <span class="badge bg-danger me-2">{{ report.sensitiveRoleCount }} rôle{% if report.sensitiveRoleCount != 1 %}s{% endif %} sensible{% if report.sensitiveRoleCount != 1 %}s{% endif %}</span>
+                    <span class="badge bg-info">{{ report.scopeCount }} périmètre{% if report.scopeCount != 1 %}s{% endif %}</span>
                 </div>
-                <div class="form-check form-switch m-0">
-                    <input class="form-check-input" type="checkbox" id="auditSensitiveOnly">
-                    <label class="form-check-label small" for="auditSensitiveOnly">Afficher uniquement les rôles sensibles</label>
-                </div>
+                {% include '@NetBSSecure/audit/_sensitive_toggle.html.twig' %}
             </div>
         </div>
 
@@ -74,21 +60,6 @@
                 </div>
             {% endif %}
         </div>
-
-        <style>
-            #auditGrants.audit-sensitive-only .audit-grant[data-has-sensitive="0"] { display: none; }
-        </style>
-        <script>
-            (function () {
-                const toggle = document.getElementById('auditSensitiveOnly');
-                const grants = document.getElementById('auditGrants');
-                if (toggle && grants) {
-                    toggle.addEventListener('change', () => {
-                        grants.classList.toggle('audit-sensitive-only', toggle.checked);
-                    });
-                }
-            })();
-        </script>
 
     </div>
 {% endblock %}

--- a/netBS/core/SecureBundle/Select2/RolesProvider.php
+++ b/netBS/core/SecureBundle/Select2/RolesProvider.php
@@ -38,7 +38,16 @@ class RolesProvider implements Select2ProviderInterface
      */
     public function toString($item)
     {
-        return $item->getRole() . " - " . $item->getDescription();
+        return $item->getRole();
+    }
+
+    /**
+     * Subtitle displayed below the role name in select2 dropdowns; not used in tags.
+     * @param BaseRole $item
+     */
+    public function toSubtitle($item): ?string
+    {
+        return $item->getDescription();
     }
 
     /**

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -36,7 +36,32 @@ final class AccessAuditService
         'ROLE_QM',
         'ROLE_TRESORIER',
         'ROLE_APMBS',
+        'ROLE_MAILING',
         'ROLE_READ_EVERYWHERE',
+        'ROLE_CREATE_EVERYWHERE',
+        'ROLE_UPDATE_EVERYWHERE',
+        'ROLE_DELETE_EVERYWHERE',
+    ];
+
+    /**
+     * Roles that bypass group-scope checks in voters:
+     * - ROLE_ADMIN: short-circuits every NetBSVoter via specialRule().
+     * - ROLE_SG: short-circuits every FichierVoter via specialRule().
+     * - ROLE_*_EVERYWHERE: short-circuits the matching CRUD operation in
+     *   NetBSVoter::voteOnAttribute regardless of scope.
+     *
+     * A user holding any of these (directly, via a fonction, via an
+     * autorisation, or via an ancestor role) can access every group, so the
+     * group-scope audit must surface them even when no autorisation targets
+     * the audited group.
+     */
+    public const GLOBAL_OVERRIDE_ROLES = [
+        'ROLE_ADMIN',
+        'ROLE_SG',
+        'ROLE_READ_EVERYWHERE',
+        'ROLE_CREATE_EVERYWHERE',
+        'ROLE_UPDATE_EVERYWHERE',
+        'ROLE_DELETE_EVERYWHERE',
     ];
 
     /**
@@ -222,27 +247,47 @@ final class AccessAuditService
             $ancestorNames[] = $r->getRole();
         }
 
-        /** @var array<int, array{user: BaseUser, grants: list<AccessGrant>}> $byUser */
+        return new ScopeAccessReport($role, $this->toEntries($this->collectAccessForRoleNames($ancestorNames)));
+    }
+
+    /**
+     * Returns the byUser map (keyed by spl_object_id) of all users effectively
+     * holding any role in $names — including the path (direct / fonction /
+     * autorisation) by which they hold it. The role lists in the returned
+     * grants are filtered to the input names so the caller sees exactly which
+     * of the requested roles each grant contributes.
+     *
+     * @param  string[] $names Role names to match against direct roles, fonction
+     *                         roles, and autorisation roles. Typically a role and
+     *                         its ancestors (since an ancestor's children expand
+     *                         down to grant the role per BaseUser::getAllRoles).
+     * @return array<int, array{user: BaseUser, grants: list<AccessGrant>}>
+     */
+    private function collectAccessForRoleNames(array $names): array
+    {
         $byUser = [];
+        if (empty($names)) {
+            return $byUser;
+        }
 
         // 1. Direct holders.
         $userRepo = $this->em->getRepository($this->secureConfig->getUserClass());
         $directHolders = $userRepo->createQueryBuilder('u')
             ->innerJoin('u.roles', 'r')
             ->where('r.role IN (:names)')
-            ->setParameter('names', $ancestorNames)
+            ->setParameter('names', $names)
             ->distinct()
             ->getQuery()->getResult();
 
         foreach ($directHolders as $u) {
-            $heldAncestors = $this->filterToAncestors($u->getDirectRoles(), $ancestorNames);
+            $held = $this->filterToAncestors($u->getDirectRoles(), $names);
             $byUser[spl_object_id($u)] = [
                 'user'   => $u,
                 'grants' => [new AccessGrant(
                     provenance: Provenance::DIRECT_ROLE,
                     sourceFonction: null,
-                    roles: $heldAncestors,
-                    explicitRoleNames: $this->roleNames($heldAncestors),
+                    roles: $held,
+                    explicitRoleNames: $this->roleNames($held),
                     scope: null,
                 )],
             ];
@@ -261,7 +306,7 @@ final class AccessAuditService
             ->where('fr.role IN (:names)')
             ->andWhere('a.dateDebut < :now')
             ->andWhere('a.dateFin > :now OR a.dateFin IS NULL')
-            ->setParameter('names', $ancestorNames)
+            ->setParameter('names', $names)
             ->setParameter('now', $now)
             ->getQuery()->getResult();
 
@@ -273,13 +318,13 @@ final class AccessAuditService
                 continue;
             }
             $uid = spl_object_id($u);
-            $heldAncestors = $this->filterToAncestors($a->getFonction()->getRoles(), $ancestorNames);
+            $held = $this->filterToAncestors($a->getFonction()->getRoles(), $names);
             $byUser[$uid] ??= ['user' => $u, 'grants' => []];
             $byUser[$uid]['grants'][] = new AccessGrant(
                 provenance: Provenance::FONCTION_ROLE,
                 sourceFonction: $a->getFonction(),
-                roles: $heldAncestors,
-                explicitRoleNames: $this->roleNames($heldAncestors),
+                roles: $held,
+                explicitRoleNames: $this->roleNames($held),
                 scope: $a->getGroupe(),
                 sourceId: $a->getId(),
             );
@@ -290,7 +335,7 @@ final class AccessAuditService
         $autorisations = $autoRepo->createQueryBuilder('o')
             ->innerJoin('o.roles', 'aor')
             ->where('aor.role IN (:names)')
-            ->setParameter('names', $ancestorNames)
+            ->setParameter('names', $names)
             ->getQuery()->getResult();
 
         foreach ($autorisations as $o) {
@@ -298,25 +343,29 @@ final class AccessAuditService
             if ($u === null) {
                 continue;
             }
-            $heldAncestors = $this->filterToAncestors($o->getRoles()->toArray(), $ancestorNames);
+            $held = $this->filterToAncestors($o->getRoles()->toArray(), $names);
             $uid = spl_object_id($u);
             $byUser[$uid] ??= ['user' => $u, 'grants' => []];
             $byUser[$uid]['grants'][] = new AccessGrant(
                 provenance: Provenance::AUTORISATION,
                 sourceFonction: null,
-                roles: $heldAncestors,
-                explicitRoleNames: $this->roleNames($heldAncestors),
+                roles: $held,
+                explicitRoleNames: $this->roleNames($held),
                 scope: $o->getGroupe(),
                 sourceId: $o->getId(),
             );
         }
 
-        $entries = array_map(
+        return $byUser;
+    }
+
+    /** @param array<int, array{user: BaseUser, grants: list<AccessGrant>}> $byUser */
+    private function toEntries(array $byUser): array
+    {
+        return array_map(
             fn($row) => new ScopeAccessEntry($row['user'], $row['grants']),
             array_values($byUser),
         );
-
-        return new ScopeAccessReport($role, $entries);
     }
 
     /**
@@ -384,12 +433,43 @@ final class AccessAuditService
             );
         }
 
-        $entries = array_map(
-            fn($row) => new ScopeAccessEntry($row['user'], $row['grants']),
-            array_values($byUser),
-        );
+        // Global-override holders: anyone with ROLE_ADMIN, ROLE_SG, or a
+        // ROLE_*_EVERYWHERE can access every group, including this one, even
+        // without an autorisation or attribution on the parent chain.
+        foreach ($this->collectAccessForRoleNames($this->globalOverrideAncestorNames()) as $uid => $row) {
+            $byUser[$uid] ??= ['user' => $row['user'], 'grants' => []];
+            foreach ($row['grants'] as $g) {
+                $byUser[$uid]['grants'][] = $g;
+            }
+        }
 
-        return new ScopeAccessReport($groupe, $entries);
+        return new ScopeAccessReport($groupe, $this->toEntries($byUser));
+    }
+
+    /**
+     * Names of the global-override roles plus all their ancestors. An ancestor
+     * grants the override role via children expansion in BaseUser::getAllRoles,
+     * so a user holding an ancestor effectively holds the override.
+     *
+     * @return string[]
+     */
+    private function globalOverrideAncestorNames(): array
+    {
+        $roleRepo = $this->em->getRepository($this->secureConfig->getRoleClass());
+        if ($roleRepo === null) {
+            return [];
+        }
+        $names = [];
+        foreach (self::GLOBAL_OVERRIDE_ROLES as $name) {
+            $role = $roleRepo->findOneBy(['role' => $name]);
+            if ($role === null) {
+                continue;
+            }
+            for ($r = $role; $r !== null; $r = $r->getParent()) {
+                $names[$r->getRole()] = true;
+            }
+        }
+        return array_keys($names);
     }
 
     /** @param BaseGroupe[] $groupes */

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -131,6 +131,7 @@ final class AccessAuditService
             provenance: Provenance::DIRECT_ROLE,
             sourceFonction: null,
             roles: $this->expand($direct),
+            explicitRoleNames: $this->roleNames($direct),
             scope: null,
         )];
     }
@@ -150,6 +151,7 @@ final class AccessAuditService
                 provenance: Provenance::FONCTION_ROLE,
                 sourceFonction: $fonction,
                 roles: $this->expand($fonction->getRoles()),
+                explicitRoleNames: $this->roleNames($fonction->getRoles()),
                 scope: $attribution->getGroupe(),
                 sourceId: $attribution->getId(),
             );
@@ -166,11 +168,25 @@ final class AccessAuditService
                 provenance: Provenance::AUTORISATION,
                 sourceFonction: null,
                 roles: $this->expand($autorisation->getRoles()),
+                explicitRoleNames: $this->roleNames($autorisation->getRoles()),
                 scope: $autorisation->getGroupe(),
                 sourceId: $autorisation->getId(),
             );
         }
         return $grants;
+    }
+
+    /**
+     * @param  iterable<BaseRole> $roles
+     * @return string[]
+     */
+    private function roleNames(iterable $roles): array
+    {
+        $names = [];
+        foreach ($roles as $r) {
+            $names[] = $r->getRole();
+        }
+        return $names;
     }
 
     /**
@@ -218,12 +234,14 @@ final class AccessAuditService
             ->getQuery()->getResult();
 
         foreach ($directHolders as $u) {
+            $heldAncestors = $this->filterToAncestors($u->getDirectRoles(), $ancestorNames);
             $byUser[spl_object_id($u)] = [
                 'user'   => $u,
                 'grants' => [new AccessGrant(
                     provenance: Provenance::DIRECT_ROLE,
                     sourceFonction: null,
-                    roles: $this->filterToAncestors($u->getDirectRoles(), $ancestorNames),
+                    roles: $heldAncestors,
+                    explicitRoleNames: $this->roleNames($heldAncestors),
                     scope: null,
                 )],
             ];
@@ -252,11 +270,13 @@ final class AccessAuditService
                 continue;
             }
             $uid = spl_object_id($u);
+            $heldAncestors = $this->filterToAncestors($a->getFonction()->getRoles(), $ancestorNames);
             $byUser[$uid] ??= ['user' => $u, 'grants' => []];
             $byUser[$uid]['grants'][] = new AccessGrant(
                 provenance: Provenance::FONCTION_ROLE,
                 sourceFonction: $a->getFonction(),
-                roles: $this->filterToAncestors($a->getFonction()->getRoles(), $ancestorNames),
+                roles: $heldAncestors,
+                explicitRoleNames: $this->roleNames($heldAncestors),
                 scope: $a->getGroupe(),
                 sourceId: $a->getId(),
             );
@@ -275,12 +295,14 @@ final class AccessAuditService
             if ($u === null) {
                 continue;
             }
+            $heldAncestors = $this->filterToAncestors($o->getRoles()->toArray(), $ancestorNames);
             $uid = spl_object_id($u);
             $byUser[$uid] ??= ['user' => $u, 'grants' => []];
             $byUser[$uid]['grants'][] = new AccessGrant(
                 provenance: Provenance::AUTORISATION,
                 sourceFonction: null,
-                roles: $this->filterToAncestors($o->getRoles()->toArray(), $ancestorNames),
+                roles: $heldAncestors,
+                explicitRoleNames: $this->roleNames($heldAncestors),
                 scope: $o->getGroupe(),
                 sourceId: $o->getId(),
             );
@@ -332,6 +354,7 @@ final class AccessAuditService
                 provenance: Provenance::AUTORISATION,
                 sourceFonction: null,
                 roles: $this->expand($autorisation->getRoles()),
+                explicitRoleNames: $this->roleNames($autorisation->getRoles()),
                 scope: $autorisation->getGroupe(),
                 sourceId: $autorisation->getId(),
             );
@@ -342,12 +365,14 @@ final class AccessAuditService
             if ($u === null) {
                 continue;
             }
+            $fonction = $attribution->getFonction();
             $uid = spl_object_id($u);
             $byUser[$uid] ??= ['user' => $u, 'grants' => []];
             $byUser[$uid]['grants'][] = new AccessGrant(
                 provenance: Provenance::FONCTION_ROLE,
-                sourceFonction: $attribution->getFonction(),
-                roles: $this->expand($attribution->getFonction()->getRoles()),
+                sourceFonction: $fonction,
+                roles: $this->expand($fonction->getRoles()),
+                explicitRoleNames: $this->roleNames($fonction->getRoles()),
                 scope: $attribution->getGroupe(),
                 sourceId: $attribution->getId(),
             );

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -38,20 +38,38 @@ final class AccessAuditService
     ];
 
     /**
-     * Returns an array keyed by sensitive role name with the count of users
-     * effectively holding that role (any path). Missing roles map to 0.
+     * Builds a "who has the keys" matrix: rows are users holding at least one
+     * sensitive role, columns are the sensitive roles. Each cell is the list
+     * of AccessGrants by which that user holds that role (empty = no access).
      *
-     * @return array<string, int>
+     * @return array{
+     *     roles: string[],
+     *     rows: list<array{user: BaseUser, cells: array<string, list<AccessGrant>>}>
+     * }
      */
-    public function countUsersForSensitiveRoles(): array
+    public function buildSensitiveRoleMatrix(): array
     {
         $repo = $this->em->getRepository($this->secureConfig->getRoleClass());
-        $counts = [];
+        $byUid = [];
+
         foreach (self::SENSITIVE_ROLES as $name) {
             $role = $repo->findOneBy(['role' => $name]);
-            $counts[$name] = $role === null ? 0 : count($this->auditRoleScope($role)->entries);
+            if ($role === null) {
+                continue;
+            }
+            foreach ($this->auditRoleScope($role)->entries as $entry) {
+                $uid = $entry->user->getId();
+                $byUid[$uid] ??= ['user' => $entry->user, 'cells' => []];
+                $byUid[$uid]['cells'][$name] = $entry->grants;
+            }
         }
-        return $counts;
+
+        usort($byUid, fn($a, $b) => strcmp(
+            (string) $a['user']->getUsername(),
+            (string) $b['user']->getUsername(),
+        ));
+
+        return ['roles' => self::SENSITIVE_ROLES, 'rows' => array_values($byUid)];
     }
 
     public function auditUser(BaseUser $user): UserAccessReport

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -37,6 +37,23 @@ final class AccessAuditService
         'ROLE_READ_EVERYWHERE',
     ];
 
+    /**
+     * Returns an array keyed by sensitive role name with the count of users
+     * effectively holding that role (any path). Missing roles map to 0.
+     *
+     * @return array<string, int>
+     */
+    public function countUsersForSensitiveRoles(): array
+    {
+        $repo = $this->em->getRepository($this->secureConfig->getRoleClass());
+        $counts = [];
+        foreach (self::SENSITIVE_ROLES as $name) {
+            $role = $repo->findOneBy(['role' => $name]);
+            $counts[$name] = $role === null ? 0 : count($this->auditRoleScope($role)->entries);
+        }
+        return $counts;
+    }
+
     public function auditUser(BaseUser $user): UserAccessReport
     {
         $grants = [

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -15,10 +15,10 @@ use NetBS\SecureBundle\Mapping\BaseUser;
 
 final class AccessAuditService
 {
-    /** @var \Closure(BaseGroupe): iterable|null  Test seam: returns Autorisation[] for a Groupe. */
+    /** @var \Closure(BaseGroupe[]): iterable|null  Test seam: returns Autorisation[] for a set of Groupes. */
     private ?\Closure $autorisationFinder = null;
 
-    /** @var \Closure(BaseGroupe): iterable|null  Test seam: returns Attribution[] for a Groupe. */
+    /** @var \Closure(BaseGroupe[]): iterable|null  Test seam: returns active Attribution[] for a set of Groupes. */
     private ?\Closure $attributionFinder = null;
 
     public function __construct(
@@ -44,23 +44,29 @@ final class AccessAuditService
      *
      * @return array{
      *     roles: string[],
-     *     rows: list<array{user: BaseUser, cells: array<string, list<AccessGrant>>}>
+     *     rows: list<array{user: BaseUser, cells: array<string, list<AccessGrant>>}>,
+     *     counts: array<string, int>,
      * }
      */
     public function buildSensitiveRoleMatrix(): array
     {
         $repo = $this->em->getRepository($this->secureConfig->getRoleClass());
-        $byUid = [];
+        /** @var BaseRole[] $roles */
+        $roles = $repo->createQueryBuilder('r')
+            ->where('r.role IN (:names)')
+            ->setParameter('names', self::SENSITIVE_ROLES)
+            ->getQuery()->getResult();
 
-        foreach (self::SENSITIVE_ROLES as $name) {
-            $role = $repo->findOneBy(['role' => $name]);
-            if ($role === null) {
-                continue;
-            }
+        $byUid  = [];
+        $counts = array_fill_keys(self::SENSITIVE_ROLES, 0);
+
+        foreach ($roles as $role) {
+            $name = $role->getRole();
             foreach ($this->auditRoleScope($role)->entries as $entry) {
                 $uid = $entry->user->getId();
                 $byUid[$uid] ??= ['user' => $entry->user, 'cells' => []];
                 $byUid[$uid]['cells'][$name] = $entry->grants;
+                $counts[$name]++;
             }
         }
 
@@ -69,7 +75,11 @@ final class AccessAuditService
             (string) $b['user']->getUsername(),
         ));
 
-        return ['roles' => self::SENSITIVE_ROLES, 'rows' => array_values($byUid)];
+        return [
+            'roles'  => self::SENSITIVE_ROLES,
+            'rows'   => array_values($byUid),
+            'counts' => $counts,
+        ];
     }
 
     public function auditUser(BaseUser $user): UserAccessReport
@@ -80,7 +90,20 @@ final class AccessAuditService
             ...$this->autorisationGrants($user),
         ];
 
-        return new UserAccessReport($user, $grants);
+        $sensitiveNames = [];
+        $scopeIds = [];
+        foreach ($grants as $g) {
+            foreach ($g->roles as $r) {
+                if (in_array($r->getRole(), self::SENSITIVE_ROLES, true)) {
+                    $sensitiveNames[$r->getRole()] = true;
+                }
+            }
+            if ($g->scope !== null) {
+                $scopeIds[$g->scope->getId()] = true;
+            }
+        }
+
+        return new UserAccessReport($user, $grants, count($sensitiveNames), count($scopeIds));
     }
 
     /** @return AccessGrant[] */
@@ -193,15 +216,19 @@ final class AccessAuditService
             ];
         }
 
-        // 2. Fonction holders (via active attributions).
+        // 2. Fonction holders (via active attributions). addSelect eager-loads
+        // the fonction and its full roles collection so the loop below doesn't
+        // trigger lazy loads on getFonction()->getRoles().
         $now = new \DateTime();
         $attrRepo = $this->em->getRepository($this->fichierConfig->getAttributionClass());
         $attributions = $attrRepo->createQueryBuilder('a')
+            ->addSelect('f', 'fr_all')
             ->innerJoin('a.fonction', 'f')
             ->innerJoin('f.roles', 'fr')
+            ->leftJoin('f.roles', 'fr_all')
             ->where('fr.role IN (:names)')
-            ->andWhere('a.dateDebut <= :now')
-            ->andWhere('a.dateFin >= :now OR a.dateFin IS NULL')
+            ->andWhere('a.dateDebut < :now')
+            ->andWhere('a.dateFin > :now OR a.dateFin IS NULL')
             ->setParameter('names', $ancestorNames)
             ->setParameter('now', $now)
             ->getQuery()->getResult();
@@ -281,38 +308,36 @@ final class AccessAuditService
         /** @var array<int, array{user: BaseUser, grants: list<AccessGrant>}> $byUser */
         $byUser = [];
 
-        foreach ($chain as $g) {
-            foreach ($this->findAutorisationsForGroupe($g) as $autorisation) {
-                $u = $autorisation->getUser();
-                if ($u === null) {
-                    continue;
-                }
-                $uid = spl_object_id($u);
-                $byUser[$uid] ??= ['user' => $u, 'grants' => []];
-                $byUser[$uid]['grants'][] = new AccessGrant(
-                    provenance: Provenance::AUTORISATION,
-                    sourceFonction: null,
-                    roles: $this->expand($autorisation->getRoles()),
-                    scope: $autorisation->getGroupe(),
-                    sourceId: $autorisation->getId(),
-                );
+        foreach ($this->findAutorisationsForGroupes($chain) as $autorisation) {
+            $u = $autorisation->getUser();
+            if ($u === null) {
+                continue;
             }
+            $uid = spl_object_id($u);
+            $byUser[$uid] ??= ['user' => $u, 'grants' => []];
+            $byUser[$uid]['grants'][] = new AccessGrant(
+                provenance: Provenance::AUTORISATION,
+                sourceFonction: null,
+                roles: $this->expand($autorisation->getRoles()),
+                scope: $autorisation->getGroupe(),
+                sourceId: $autorisation->getId(),
+            );
+        }
 
-            foreach ($this->findAttributionsForGroupe($g) as $attribution) {
-                $u = $attribution->getMembre()?->getUser();
-                if ($u === null) {
-                    continue;
-                }
-                $uid = spl_object_id($u);
-                $byUser[$uid] ??= ['user' => $u, 'grants' => []];
-                $byUser[$uid]['grants'][] = new AccessGrant(
-                    provenance: Provenance::FONCTION_ROLE,
-                    sourceFonction: $attribution->getFonction(),
-                    roles: $this->expand($attribution->getFonction()->getRoles()),
-                    scope: $attribution->getGroupe(),
-                    sourceId: $attribution->getId(),
-                );
+        foreach ($this->findAttributionsForGroupes($chain) as $attribution) {
+            $u = $attribution->getMembre()?->getUser();
+            if ($u === null) {
+                continue;
             }
+            $uid = spl_object_id($u);
+            $byUser[$uid] ??= ['user' => $u, 'grants' => []];
+            $byUser[$uid]['grants'][] = new AccessGrant(
+                provenance: Provenance::FONCTION_ROLE,
+                sourceFonction: $attribution->getFonction(),
+                roles: $this->expand($attribution->getFonction()->getRoles()),
+                scope: $attribution->getGroupe(),
+                sourceId: $attribution->getId(),
+            );
         }
 
         $entries = array_map(
@@ -323,28 +348,41 @@ final class AccessAuditService
         return new ScopeAccessReport($groupe, $entries);
     }
 
-    private function findAutorisationsForGroupe(BaseGroupe $g): iterable
+    /** @param BaseGroupe[] $groupes */
+    private function findAutorisationsForGroupes(array $groupes): iterable
     {
         if ($this->autorisationFinder !== null) {
-            return ($this->autorisationFinder)($g);
+            return ($this->autorisationFinder)($groupes);
+        }
+        if (empty($groupes)) {
+            return [];
         }
         $repo = $this->em->getRepository($this->secureConfig->getAutorisationClass());
-        return $repo->findBy(['groupe' => $g]);
+        return $repo->createQueryBuilder('o')
+            ->where('o.groupe IN (:groupes)')
+            ->setParameter('groupes', $groupes)
+            ->getQuery()->getResult();
     }
 
-    private function findAttributionsForGroupe(BaseGroupe $g): iterable
+    /** @param BaseGroupe[] $groupes */
+    private function findAttributionsForGroupes(array $groupes): iterable
     {
         if ($this->attributionFinder !== null) {
-            return ($this->attributionFinder)($g);
+            return ($this->attributionFinder)($groupes);
+        }
+        if (empty($groupes)) {
+            return [];
         }
         $now = new \DateTime();
-        $class = $this->fichierConfig->getAttributionClass();
-        $repo = $this->em->getRepository($class);
+        $repo = $this->em->getRepository($this->fichierConfig->getAttributionClass());
         return $repo->createQueryBuilder('a')
-            ->where('a.groupe = :g')
-            ->andWhere('a.dateDebut <= :now')
-            ->andWhere('a.dateFin >= :now OR a.dateFin IS NULL')
-            ->setParameter('g', $g)
+            ->addSelect('f', 'fr')
+            ->innerJoin('a.fonction', 'f')
+            ->leftJoin('f.roles', 'fr')
+            ->where('a.groupe IN (:groupes)')
+            ->andWhere('a.dateDebut < :now')
+            ->andWhere('a.dateFin > :now OR a.dateFin IS NULL')
+            ->setParameter('groupes', $groupes)
             ->setParameter('now', $now)
             ->getQuery()->getResult();
     }

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Service;
+
+use NetBS\SecureBundle\Audit\AccessGrant;
+use NetBS\SecureBundle\Audit\Provenance;
+use NetBS\SecureBundle\Audit\UserAccessReport;
+use NetBS\SecureBundle\Mapping\BaseRole;
+use NetBS\SecureBundle\Mapping\BaseUser;
+
+final class AccessAuditService
+{
+    /** Hard-coded curated list — same set already special-cased in DebugUserRolesCommand. */
+    public const SENSITIVE_ROLES = [
+        'ROLE_ADMIN',
+        'ROLE_COMMANDANT',
+        'ROLE_SG',
+        'ROLE_TRESORIER',
+        'ROLE_APMBS',
+        'ROLE_READ_EVERYWHERE',
+    ];
+
+    public function auditUser(BaseUser $user): UserAccessReport
+    {
+        $grants = [
+            ...$this->directRoleGrants($user),
+            ...$this->fonctionRoleGrants($user),
+            ...$this->autorisationGrants($user),
+        ];
+
+        return new UserAccessReport($user, $grants);
+    }
+
+    /** @return AccessGrant[] */
+    private function directRoleGrants(BaseUser $user): array
+    {
+        $direct = $user->getDirectRoles();
+        if (empty($direct)) {
+            return [];
+        }
+
+        return [new AccessGrant(
+            provenance: Provenance::DIRECT_ROLE,
+            sourceFonction: null,
+            roles: $this->expand($direct),
+            scope: null,
+        )];
+    }
+
+    /** @return AccessGrant[] */
+    private function fonctionRoleGrants(BaseUser $user): array
+    {
+        $membre = $user->getMembre();
+        if (!$membre) {
+            return [];
+        }
+
+        $grants = [];
+        foreach ($membre->getActivesAttributions() as $attribution) {
+            $fonction = $attribution->getFonction();
+            $grants[] = new AccessGrant(
+                provenance: Provenance::FONCTION_ROLE,
+                sourceFonction: $fonction,
+                roles: $this->expand($fonction->getRoles()),
+                scope: $attribution->getGroupe(),
+                sourceId: $attribution->getId(),
+            );
+        }
+        return $grants;
+    }
+
+    /** @return AccessGrant[] */
+    private function autorisationGrants(BaseUser $user): array
+    {
+        $grants = [];
+        foreach ($user->getAutorisations() as $autorisation) {
+            $grants[] = new AccessGrant(
+                provenance: Provenance::AUTORISATION,
+                sourceFonction: null,
+                roles: $this->expand($autorisation->getRoles()),
+                scope: $autorisation->getGroupe(),
+                sourceId: $autorisation->getId(),
+            );
+        }
+        return $grants;
+    }
+
+    /**
+     * @param iterable<BaseRole> $roles
+     * @return BaseRole[]
+     */
+    private function expand(iterable $roles): array
+    {
+        $out = [];
+        foreach ($roles as $r) {
+            foreach ($r->getChildrenRecursive() as $child) {
+                $out[$child->getRole()] = $child;
+            }
+        }
+        return array_values($out);
+    }
+}

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -33,6 +33,7 @@ final class AccessAuditService
         'ROLE_ADMIN',
         'ROLE_COMMANDANT',
         'ROLE_SG',
+        'ROLE_QM',
         'ROLE_TRESORIER',
         'ROLE_APMBS',
         'ROLE_READ_EVERYWHERE',

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -28,7 +28,6 @@ final class AccessAuditService
         private readonly \NetBS\FichierBundle\Service\FichierConfig $fichierConfig,
     ) {}
 
-    /** Hard-coded curated list — same set already special-cased in DebugUserRolesCommand. */
     public const SENSITIVE_ROLES = [
         'ROLE_ADMIN',
         'ROLE_COMMANDANT',
@@ -44,16 +43,9 @@ final class AccessAuditService
     ];
 
     /**
-     * Roles that bypass group-scope checks in voters:
-     * - ROLE_ADMIN: short-circuits every NetBSVoter via specialRule().
-     * - ROLE_SG: short-circuits every FichierVoter via specialRule().
-     * - ROLE_*_EVERYWHERE: short-circuits the matching CRUD operation in
-     *   NetBSVoter::voteOnAttribute regardless of scope.
-     *
-     * A user holding any of these (directly, via a fonction, via an
-     * autorisation, or via an ancestor role) can access every group, so the
-     * group-scope audit must surface them even when no autorisation targets
-     * the audited group.
+     * Roles that bypass group-scope checks in voters: ROLE_ADMIN
+     * (NetBSVoter::specialRule), ROLE_SG (FichierVoter::specialRule), and
+     * ROLE_*_EVERYWHERE (NetBSVoter::voteOnAttribute, line 60).
      */
     public const GLOBAL_OVERRIDE_ROLES = [
         'ROLE_ADMIN',
@@ -240,27 +232,32 @@ final class AccessAuditService
 
     private function auditRoleScope(BaseRole $role): ScopeAccessReport
     {
-        // Walk UP the role tree: holding the role itself or any ancestor effectively
-        // grants the audited role (per BaseUser::getAllRoles, which expands children).
-        $ancestorNames = [];
-        for ($r = $role; $r !== null; $r = $r->getParent()) {
-            $ancestorNames[] = $r->getRole();
-        }
-
-        return new ScopeAccessReport($role, $this->toEntries($this->collectAccessForRoleNames($ancestorNames)));
+        // Holding any ancestor effectively grants the role, since BaseUser::getAllRoles expands children.
+        return new ScopeAccessReport(
+            $role,
+            $this->toEntries($this->collectAccessForRoleNames($this->ancestorNamesOf($role))),
+        );
     }
 
     /**
-     * Returns the byUser map (keyed by spl_object_id) of all users effectively
-     * holding any role in $names — including the path (direct / fonction /
-     * autorisation) by which they hold it. The role lists in the returned
-     * grants are filtered to the input names so the caller sees exactly which
-     * of the requested roles each grant contributes.
+     * @return string[] Names of $role itself plus all ancestors walking up via getParent().
+     */
+    private function ancestorNamesOf(BaseRole $role): array
+    {
+        $names = [];
+        for ($r = $role; $r !== null; $r = $r->getParent()) {
+            $names[] = $r->getRole();
+        }
+        return $names;
+    }
+
+    /**
+     * Users effectively holding any role in $names, with the grant path
+     * (direct / fonction / autorisation) by which they hold it. Grant role
+     * lists are filtered to $names so callers see exactly which requested
+     * roles each grant contributes.
      *
-     * @param  string[] $names Role names to match against direct roles, fonction
-     *                         roles, and autorisation roles. Typically a role and
-     *                         its ancestors (since an ancestor's children expand
-     *                         down to grant the role per BaseUser::getAllRoles).
+     * @param  string[] $names
      * @return array<int, array{user: BaseUser, grants: list<AccessGrant>}>
      */
     private function collectAccessForRoleNames(array $names): array
@@ -433,26 +430,29 @@ final class AccessAuditService
             );
         }
 
-        // Global-override holders: anyone with ROLE_ADMIN, ROLE_SG, or a
-        // ROLE_*_EVERYWHERE can access every group, including this one, even
-        // without an autorisation or attribution on the parent chain.
+        // Holders of any GLOBAL_OVERRIDE_ROLES role have access to every group, even with no
+        // autorisation/attribution on the parent chain. Dedup against the chain pass: a single
+        // attribution or autorisation can match both passes and would otherwise be reported twice.
         foreach ($this->collectAccessForRoleNames($this->globalOverrideAncestorNames()) as $uid => $row) {
             $byUser[$uid] ??= ['user' => $row['user'], 'grants' => []];
+            $seen = [];
+            foreach ($byUser[$uid]['grants'] as $existing) {
+                $seen[$existing->provenance->value . ':' . ($existing->sourceId ?? '')] = true;
+            }
             foreach ($row['grants'] as $g) {
+                $key = $g->provenance->value . ':' . ($g->sourceId ?? '');
+                if (isset($seen[$key])) {
+                    continue;
+                }
                 $byUser[$uid]['grants'][] = $g;
+                $seen[$key] = true;
             }
         }
 
         return new ScopeAccessReport($groupe, $this->toEntries($byUser));
     }
 
-    /**
-     * Names of the global-override roles plus all their ancestors. An ancestor
-     * grants the override role via children expansion in BaseUser::getAllRoles,
-     * so a user holding an ancestor effectively holds the override.
-     *
-     * @return string[]
-     */
+    /** @return string[] Global-override role names plus all their ancestors. */
     private function globalOverrideAncestorNames(): array
     {
         $roleRepo = $this->em->getRepository($this->secureConfig->getRoleClass());
@@ -460,13 +460,9 @@ final class AccessAuditService
             return [];
         }
         $names = [];
-        foreach (self::GLOBAL_OVERRIDE_ROLES as $name) {
-            $role = $roleRepo->findOneBy(['role' => $name]);
-            if ($role === null) {
-                continue;
-            }
-            for ($r = $role; $r !== null; $r = $r->getParent()) {
-                $names[$r->getRole()] = true;
+        foreach ($roleRepo->findBy(['role' => self::GLOBAL_OVERRIDE_ROLES]) as $role) {
+            foreach ($this->ancestorNamesOf($role) as $n) {
+                $names[$n] = true;
             }
         }
         return array_keys($names);

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -264,8 +264,10 @@ final class AccessAuditService
             ->setParameter('now', $now)
             ->getQuery()->getResult();
 
+        $usersByMembre = $this->usersByMembreId($attributions);
+
         foreach ($attributions as $a) {
-            $u = $a->getMembre()?->getUser();
+            $u = $usersByMembre[$a->getMembre()?->getId()] ?? null;
             if ($u === null) {
                 continue;
             }
@@ -360,8 +362,11 @@ final class AccessAuditService
             );
         }
 
-        foreach ($this->findAttributionsForGroupes($chain) as $attribution) {
-            $u = $attribution->getMembre()?->getUser();
+        $chainAttributions = $this->findAttributionsForGroupes($chain);
+        $usersByMembre = $this->usersByMembreId($chainAttributions);
+
+        foreach ($chainAttributions as $attribution) {
+            $u = $usersByMembre[$attribution->getMembre()?->getId()] ?? null;
             if ($u === null) {
                 continue;
             }
@@ -400,6 +405,41 @@ final class AccessAuditService
             ->where('o.groupe IN (:groupes)')
             ->setParameter('groupes', $groupes)
             ->getQuery()->getResult();
+    }
+
+    /**
+     * Looks up users by their membre id. BaseMembre has no inverse pointer to
+     * User, so we query in one batch and return a map keyed by membre id.
+     *
+     * @param  iterable<\NetBS\FichierBundle\Mapping\BaseAttribution> $attributions
+     * @return array<int, BaseUser>
+     */
+    private function usersByMembreId(iterable $attributions): array
+    {
+        $membreIds = [];
+        foreach ($attributions as $a) {
+            $m = $a->getMembre();
+            if ($m !== null) {
+                $membreIds[$m->getId()] = true;
+            }
+        }
+        if (empty($membreIds)) {
+            return [];
+        }
+        $repo = $this->em->getRepository($this->secureConfig->getUserClass());
+        $users = $repo->createQueryBuilder('u')
+            ->where('IDENTITY(u.membre) IN (:ids)')
+            ->setParameter('ids', array_keys($membreIds))
+            ->getQuery()->getResult();
+
+        $map = [];
+        foreach ($users as $u) {
+            $m = $u->getMembre();
+            if ($m !== null) {
+                $map[$m->getId()] = $u;
+            }
+        }
+        return $map;
     }
 
     /** @param BaseGroupe[] $groupes */

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -127,22 +127,22 @@ final class AccessAuditService
 
     private function auditRoleScope(BaseRole $role): ScopeAccessReport
     {
-        // All role names this scope covers (role + descendants).
-        $roleNames = array_values(array_unique(array_map(
-            fn(BaseRole $r) => $r->getRole(),
-            $role->getChildrenRecursive(),
-        )));
+        // Walk UP the role tree: holding the role itself or any ancestor effectively
+        // grants the audited role (per BaseUser::getAllRoles, which expands children).
+        $ancestorNames = [];
+        for ($r = $role; $r !== null; $r = $r->getParent()) {
+            $ancestorNames[] = $r->getRole();
+        }
 
         /** @var array<int, array{user: BaseUser, grants: list<AccessGrant>}> $byUser */
         $byUser = [];
 
         // 1. Direct holders.
-        $userClass = $this->secureConfig->getUserClass();
-        $userRepo = $this->em->getRepository($userClass);
+        $userRepo = $this->em->getRepository($this->secureConfig->getUserClass());
         $directHolders = $userRepo->createQueryBuilder('u')
             ->innerJoin('u.roles', 'r')
             ->where('r.role IN (:names)')
-            ->setParameter('names', $roleNames)
+            ->setParameter('names', $ancestorNames)
             ->distinct()
             ->getQuery()->getResult();
 
@@ -152,7 +152,7 @@ final class AccessAuditService
                 'grants' => [new AccessGrant(
                     provenance: Provenance::DIRECT_ROLE,
                     sourceFonction: null,
-                    roles: [$role],
+                    roles: $this->filterToAncestors($u->getDirectRoles(), $ancestorNames),
                     scope: null,
                 )],
             ];
@@ -160,15 +160,14 @@ final class AccessAuditService
 
         // 2. Fonction holders (via active attributions).
         $now = new \DateTime();
-        $attrClass = $this->fichierConfig->getAttributionClass();
-        $attrRepo = $this->em->getRepository($attrClass);
+        $attrRepo = $this->em->getRepository($this->fichierConfig->getAttributionClass());
         $attributions = $attrRepo->createQueryBuilder('a')
             ->innerJoin('a.fonction', 'f')
             ->innerJoin('f.roles', 'fr')
             ->where('fr.role IN (:names)')
             ->andWhere('a.dateDebut <= :now')
             ->andWhere('a.dateFin >= :now OR a.dateFin IS NULL')
-            ->setParameter('names', $roleNames)
+            ->setParameter('names', $ancestorNames)
             ->setParameter('now', $now)
             ->getQuery()->getResult();
 
@@ -182,20 +181,18 @@ final class AccessAuditService
             $byUser[$uid]['grants'][] = new AccessGrant(
                 provenance: Provenance::FONCTION_ROLE,
                 sourceFonction: $a->getFonction(),
-                roles: [$role],
+                roles: $this->filterToAncestors($a->getFonction()->getRoles(), $ancestorNames),
                 scope: $a->getGroupe(),
                 sourceId: $a->getId(),
             );
         }
 
-        // 3. Autorisation holders.
-        $autoClass = $this->secureConfig->getAutorisationClass();
-        $autoRepo = $this->em->getRepository($autoClass);
-        // Alias 'or' is a reserved keyword in DQL — use 'aor' instead.
+        // 3. Autorisation holders. Alias 'or' is reserved in DQL; use 'aor'.
+        $autoRepo = $this->em->getRepository($this->secureConfig->getAutorisationClass());
         $autorisations = $autoRepo->createQueryBuilder('o')
             ->innerJoin('o.roles', 'aor')
             ->where('aor.role IN (:names)')
-            ->setParameter('names', $roleNames)
+            ->setParameter('names', $ancestorNames)
             ->getQuery()->getResult();
 
         foreach ($autorisations as $o) {
@@ -208,7 +205,7 @@ final class AccessAuditService
             $byUser[$uid]['grants'][] = new AccessGrant(
                 provenance: Provenance::AUTORISATION,
                 sourceFonction: null,
-                roles: [$role],
+                roles: $this->filterToAncestors($o->getRoles()->toArray(), $ancestorNames),
                 scope: $o->getGroupe(),
                 sourceId: $o->getId(),
             );
@@ -220,6 +217,22 @@ final class AccessAuditService
         );
 
         return new ScopeAccessReport($role, $entries);
+    }
+
+    /**
+     * @param  iterable<BaseRole> $roles
+     * @param  string[]           $ancestorNames
+     * @return BaseRole[]
+     */
+    private function filterToAncestors(iterable $roles, array $ancestorNames): array
+    {
+        $out = [];
+        foreach ($roles as $r) {
+            if (in_array($r->getRole(), $ancestorNames, true)) {
+                $out[] = $r;
+            }
+        }
+        return $out;
     }
 
     private function auditGroupeScope(BaseGroupe $groupe): ScopeAccessReport

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -9,6 +9,7 @@ use NetBS\SecureBundle\Audit\AccessGrant;
 use NetBS\SecureBundle\Audit\Provenance;
 use NetBS\SecureBundle\Audit\ScopeAccessEntry;
 use NetBS\SecureBundle\Audit\ScopeAccessReport;
+use NetBS\SecureBundle\Audit\SensitiveRoleCell;
 use NetBS\SecureBundle\Audit\UserAccessReport;
 use NetBS\SecureBundle\Mapping\BaseRole;
 use NetBS\SecureBundle\Mapping\BaseUser;
@@ -39,13 +40,14 @@ final class AccessAuditService
 
     /**
      * Builds a "who has the keys" matrix: rows are users holding at least one
-     * sensitive role, columns are the sensitive roles. Each cell is the list
-     * of AccessGrants by which that user holds that role (empty = no access).
+     * sensitive role, columns are the sensitive roles. Each cell carries the
+     * AccessGrants and whether at least one of them is explicit (holds the
+     * audited role itself, not just an ancestor role that contains it).
      *
      * @return array{
      *     roles: string[],
-     *     rows: list<array{user: BaseUser, cells: array<string, list<AccessGrant>>}>,
-     *     counts: array<string, int>,
+     *     rows: list<array{user: BaseUser, cells: array<string, SensitiveRoleCell>}>,
+     *     counts: array{explicit: array<string, int>, inherited: array<string, int>},
      * }
      */
     public function buildSensitiveRoleMatrix(): array
@@ -57,16 +59,27 @@ final class AccessAuditService
             ->setParameter('names', self::SENSITIVE_ROLES)
             ->getQuery()->getResult();
 
-        $byUid  = [];
-        $counts = array_fill_keys(self::SENSITIVE_ROLES, 0);
+        $byUid     = [];
+        $explicit  = array_fill_keys(self::SENSITIVE_ROLES, 0);
+        $inherited = array_fill_keys(self::SENSITIVE_ROLES, 0);
 
         foreach ($roles as $role) {
             $name = $role->getRole();
             foreach ($this->auditRoleScope($role)->entries as $entry) {
+                $cellExplicit = false;
+                foreach ($entry->grants as $g) {
+                    foreach ($g->roles as $r) {
+                        if ($r->getRole() === $name) {
+                            $cellExplicit = true;
+                            break 2;
+                        }
+                    }
+                }
+
                 $uid = $entry->user->getId();
                 $byUid[$uid] ??= ['user' => $entry->user, 'cells' => []];
-                $byUid[$uid]['cells'][$name] = $entry->grants;
-                $counts[$name]++;
+                $byUid[$uid]['cells'][$name] = new SensitiveRoleCell($entry->grants, $cellExplicit);
+                $cellExplicit ? $explicit[$name]++ : $inherited[$name]++;
             }
         }
 
@@ -78,7 +91,7 @@ final class AccessAuditService
         return [
             'roles'  => self::SENSITIVE_ROLES,
             'rows'   => array_values($byUid),
-            'counts' => $counts,
+            'counts' => ['explicit' => $explicit, 'inherited' => $inherited],
         ];
     }
 

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -122,8 +122,104 @@ final class AccessAuditService
         if ($scope instanceof BaseGroupe) {
             return $this->auditGroupeScope($scope);
         }
-        // Role branch — Task 4 will implement. Empty stub for now.
-        return new ScopeAccessReport($scope, []);
+        return $this->auditRoleScope($scope);
+    }
+
+    private function auditRoleScope(BaseRole $role): ScopeAccessReport
+    {
+        // All role names this scope covers (role + descendants).
+        $roleNames = array_values(array_unique(array_map(
+            fn(BaseRole $r) => $r->getRole(),
+            $role->getChildrenRecursive(),
+        )));
+
+        /** @var array<int, array{user: BaseUser, grants: list<AccessGrant>}> $byUser */
+        $byUser = [];
+
+        // 1. Direct holders.
+        $userClass = $this->secureConfig->getUserClass();
+        $userRepo = $this->em->getRepository($userClass);
+        $directHolders = $userRepo->createQueryBuilder('u')
+            ->innerJoin('u.roles', 'r')
+            ->where('r.role IN (:names)')
+            ->setParameter('names', $roleNames)
+            ->distinct()
+            ->getQuery()->getResult();
+
+        foreach ($directHolders as $u) {
+            $byUser[spl_object_id($u)] = [
+                'user'   => $u,
+                'grants' => [new AccessGrant(
+                    provenance: Provenance::DIRECT_ROLE,
+                    sourceFonction: null,
+                    roles: [$role],
+                    scope: null,
+                )],
+            ];
+        }
+
+        // 2. Fonction holders (via active attributions).
+        $now = new \DateTime();
+        $attrClass = $this->fichierConfig->getAttributionClass();
+        $attrRepo = $this->em->getRepository($attrClass);
+        $attributions = $attrRepo->createQueryBuilder('a')
+            ->innerJoin('a.fonction', 'f')
+            ->innerJoin('f.roles', 'fr')
+            ->where('fr.role IN (:names)')
+            ->andWhere('a.dateDebut <= :now')
+            ->andWhere('a.dateFin >= :now OR a.dateFin IS NULL')
+            ->setParameter('names', $roleNames)
+            ->setParameter('now', $now)
+            ->getQuery()->getResult();
+
+        foreach ($attributions as $a) {
+            $u = $a->getMembre()?->getUser();
+            if ($u === null) {
+                continue;
+            }
+            $uid = spl_object_id($u);
+            $byUser[$uid] ??= ['user' => $u, 'grants' => []];
+            $byUser[$uid]['grants'][] = new AccessGrant(
+                provenance: Provenance::FONCTION_ROLE,
+                sourceFonction: $a->getFonction(),
+                roles: [$role],
+                scope: $a->getGroupe(),
+                sourceId: $a->getId(),
+            );
+        }
+
+        // 3. Autorisation holders.
+        $autoClass = $this->secureConfig->getAutorisationClass();
+        $autoRepo = $this->em->getRepository($autoClass);
+        // Alias 'or' is a reserved keyword in DQL — use 'aor' instead.
+        $autorisations = $autoRepo->createQueryBuilder('o')
+            ->innerJoin('o.roles', 'aor')
+            ->where('aor.role IN (:names)')
+            ->setParameter('names', $roleNames)
+            ->getQuery()->getResult();
+
+        foreach ($autorisations as $o) {
+            $u = $o->getUser();
+            if ($u === null) {
+                continue;
+            }
+            $uid = spl_object_id($u);
+            $byUser[$uid] ??= ['user' => $u, 'grants' => []];
+            $byUser[$uid]['grants'][] = new AccessGrant(
+                provenance: Provenance::AUTORISATION,
+                sourceFonction: null,
+                roles: [$role],
+                scope: $o->getGroupe(),
+                sourceId: $o->getId(),
+            );
+        }
+
+        $entries = array_map(
+            fn($row) => new ScopeAccessEntry($row['user'], $row['grants']),
+            array_values($byUser),
+        );
+
+        return new ScopeAccessReport($role, $entries);
     }
 
     private function auditGroupeScope(BaseGroupe $groupe): ScopeAccessReport

--- a/netBS/core/SecureBundle/Service/AccessAuditService.php
+++ b/netBS/core/SecureBundle/Service/AccessAuditService.php
@@ -4,14 +4,29 @@ declare(strict_types=1);
 
 namespace NetBS\SecureBundle\Service;
 
+use NetBS\FichierBundle\Mapping\BaseGroupe;
 use NetBS\SecureBundle\Audit\AccessGrant;
 use NetBS\SecureBundle\Audit\Provenance;
+use NetBS\SecureBundle\Audit\ScopeAccessEntry;
+use NetBS\SecureBundle\Audit\ScopeAccessReport;
 use NetBS\SecureBundle\Audit\UserAccessReport;
 use NetBS\SecureBundle\Mapping\BaseRole;
 use NetBS\SecureBundle\Mapping\BaseUser;
 
 final class AccessAuditService
 {
+    /** @var \Closure(BaseGroupe): iterable|null  Test seam: returns Autorisation[] for a Groupe. */
+    private ?\Closure $autorisationFinder = null;
+
+    /** @var \Closure(BaseGroupe): iterable|null  Test seam: returns Attribution[] for a Groupe. */
+    private ?\Closure $attributionFinder = null;
+
+    public function __construct(
+        private readonly \Doctrine\ORM\EntityManagerInterface $em,
+        private readonly \NetBS\SecureBundle\Service\SecureConfig $secureConfig,
+        private readonly \NetBS\FichierBundle\Service\FichierConfig $fichierConfig,
+    ) {}
+
     /** Hard-coded curated list — same set already special-cased in DebugUserRolesCommand. */
     public const SENSITIVE_ROLES = [
         'ROLE_ADMIN',
@@ -100,5 +115,93 @@ final class AccessAuditService
             }
         }
         return array_values($out);
+    }
+
+    public function auditScope(BaseGroupe|BaseRole $scope): ScopeAccessReport
+    {
+        if ($scope instanceof BaseGroupe) {
+            return $this->auditGroupeScope($scope);
+        }
+        // Role branch — Task 4 will implement. Empty stub for now.
+        return new ScopeAccessReport($scope, []);
+    }
+
+    private function auditGroupeScope(BaseGroupe $groupe): ScopeAccessReport
+    {
+        // Walk parent chain: leaf -> ... -> root.
+        $chain = [];
+        for ($g = $groupe; $g !== null; $g = $g->getParent()) {
+            $chain[] = $g;
+        }
+
+        /** @var array<int, array{user: BaseUser, grants: list<AccessGrant>}> $byUser */
+        $byUser = [];
+
+        foreach ($chain as $g) {
+            foreach ($this->findAutorisationsForGroupe($g) as $autorisation) {
+                $u = $autorisation->getUser();
+                if ($u === null) {
+                    continue;
+                }
+                $uid = spl_object_id($u);
+                $byUser[$uid] ??= ['user' => $u, 'grants' => []];
+                $byUser[$uid]['grants'][] = new AccessGrant(
+                    provenance: Provenance::AUTORISATION,
+                    sourceFonction: null,
+                    roles: $this->expand($autorisation->getRoles()),
+                    scope: $autorisation->getGroupe(),
+                    sourceId: $autorisation->getId(),
+                );
+            }
+
+            foreach ($this->findAttributionsForGroupe($g) as $attribution) {
+                $u = $attribution->getMembre()?->getUser();
+                if ($u === null) {
+                    continue;
+                }
+                $uid = spl_object_id($u);
+                $byUser[$uid] ??= ['user' => $u, 'grants' => []];
+                $byUser[$uid]['grants'][] = new AccessGrant(
+                    provenance: Provenance::FONCTION_ROLE,
+                    sourceFonction: $attribution->getFonction(),
+                    roles: $this->expand($attribution->getFonction()->getRoles()),
+                    scope: $attribution->getGroupe(),
+                    sourceId: $attribution->getId(),
+                );
+            }
+        }
+
+        $entries = array_map(
+            fn($row) => new ScopeAccessEntry($row['user'], $row['grants']),
+            array_values($byUser),
+        );
+
+        return new ScopeAccessReport($groupe, $entries);
+    }
+
+    private function findAutorisationsForGroupe(BaseGroupe $g): iterable
+    {
+        if ($this->autorisationFinder !== null) {
+            return ($this->autorisationFinder)($g);
+        }
+        $repo = $this->em->getRepository($this->secureConfig->getAutorisationClass());
+        return $repo->findBy(['groupe' => $g]);
+    }
+
+    private function findAttributionsForGroupe(BaseGroupe $g): iterable
+    {
+        if ($this->attributionFinder !== null) {
+            return ($this->attributionFinder)($g);
+        }
+        $now = new \DateTime();
+        $class = $this->fichierConfig->getAttributionClass();
+        $repo = $this->em->getRepository($class);
+        return $repo->createQueryBuilder('a')
+            ->where('a.groupe = :g')
+            ->andWhere('a.dateDebut <= :now')
+            ->andWhere('a.dateFin >= :now OR a.dateFin IS NULL')
+            ->setParameter('g', $g)
+            ->setParameter('now', $now)
+            ->getQuery()->getResult();
     }
 }

--- a/netBS/core/SecureBundle/Service/RoleSyncReport.php
+++ b/netBS/core/SecureBundle/Service/RoleSyncReport.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Service;
+
+/**
+ * Summary of what a single {@see RoleTreeSyncer::syncAll} run did.
+ *
+ * Role names are tracked here, not Role entities, so the report stays
+ * meaningful after the entity manager is cleared.
+ */
+final class RoleSyncReport
+{
+    /** @var string[] */
+    public array $created = [];
+
+    /** @var string[] */
+    public array $updated = [];
+
+    /** @var string[] */
+    public array $unchanged = [];
+
+    /** Number of duplicate role rows removed at the start of the sync. */
+    public int $dedupedFrom = 0;
+}

--- a/netBS/core/SecureBundle/Service/RoleTreeSourceInterface.php
+++ b/netBS/core/SecureBundle/Service/RoleTreeSourceInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Service;
+
+/**
+ * Bundle-supplied source of role-tree definitions. Implementations are
+ * tag-collected and processed by {@see RoleTreeSyncer} in {@see getOrder}
+ * order — a source that requires an existing role row as its root parent
+ * must run after the source that creates that root.
+ *
+ * Tag service id `netbs.role_tree_source`.
+ */
+interface RoleTreeSourceInterface
+{
+    /**
+     * Absolute path to the YAML file describing this source's role subtree.
+     * The file's top-level key must be `roles`, mapping role-name to
+     * { poids, description?, children? } nodes.
+     */
+    public function getYamlPath(): string;
+
+    /**
+     * Name of the existing role under which the entire subtree of this
+     * source should be grafted, or null if the subtree's top-level roles
+     * are themselves root roles.
+     *
+     * The syncer will look up this role at the start of processing and
+     * abort if it doesn't yet exist in the database.
+     */
+    public function getRootParent(): ?string;
+
+    /**
+     * Sort key. Sources with smaller order run first. Use this to ensure
+     * any source whose {@see getRootParent} points at a role exists by
+     * the time it runs.
+     */
+    public function getOrder(): int;
+}

--- a/netBS/core/SecureBundle/Service/RoleTreeSyncer.php
+++ b/netBS/core/SecureBundle/Service/RoleTreeSyncer.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Service;
+
+use Doctrine\ORM\EntityManagerInterface;
+use NetBS\SecureBundle\Entity\Role;
+use NetBS\SecureBundle\Mapping\BaseRole;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * Reconciles the role tree in `netbs_secure_roles` with YAML definitions
+ * supplied by {@see RoleTreeSourceInterface} services tagged
+ * `netbs.role_tree_source`.
+ *
+ * Behaviour for each role in each source's YAML:
+ *  - Looked up by name; if missing, created.
+ *  - If present, `poids`, `description`, and `parent` are reset to match.
+ *  - Children recurse with the just-upserted node as their parent.
+ *
+ * Roles that exist in the DB but not in any YAML are left alone (the
+ * command surfaces them as orphans but does not delete them — anyone
+ * could have added them through the admin UI).
+ *
+ * Touches only `netbs_secure_roles`. Never reads or writes user, fonction,
+ * membre, autorisation, or any other table.
+ */
+final class RoleTreeSyncer
+{
+    /** @var iterable<RoleTreeSourceInterface> */
+    private iterable $sources;
+
+    /**
+     * @param iterable<RoleTreeSourceInterface> $sources Tag-collected role sources.
+     */
+    public function __construct(
+        private readonly EntityManagerInterface $em,
+        private readonly SecureConfig $config,
+        iterable $sources,
+    ) {
+        $this->sources = $sources;
+    }
+
+    public function syncAll(): RoleSyncReport
+    {
+        $sorted = is_array($this->sources) ? $this->sources : iterator_to_array($this->sources, false);
+        usort($sorted, static fn (RoleTreeSourceInterface $a, RoleTreeSourceInterface $b) => $a->getOrder() <=> $b->getOrder());
+
+        $report = new RoleSyncReport();
+        $repo = $this->em->getRepository(Role::class);
+
+        // Self-heal first: collapse any duplicate role rows that share a name.
+        // Idempotent — does nothing on an already-clean DB.
+        $report->dedupedFrom += $this->dedupeRoleRowsByName();
+
+        foreach ($sorted as $source) {
+            $data = Yaml::parseFile($source->getYamlPath())['roles'] ?? [];
+
+            $rootParent = null;
+            if ($source->getRootParent() !== null) {
+                $rootParent = $repo->findOneBy(['role' => $source->getRootParent()]);
+                if ($rootParent === null) {
+                    throw new \RuntimeException(sprintf(
+                        'Cannot sync %s: required root parent role "%s" not found in database. '
+                        . 'Ensure the source that creates it (lower getOrder) runs first.',
+                        $source->getYamlPath(),
+                        $source->getRootParent()
+                    ));
+                }
+            }
+
+            $this->syncTree($data, $rootParent, $report);
+            $this->em->flush();
+        }
+
+        return $report;
+    }
+
+    /**
+     * @param array<string, array{poids?: int, description?: string, children?: array}> $data
+     */
+    private function syncTree(array $data, ?BaseRole $parent, RoleSyncReport $report): void
+    {
+        $roleClass = $this->config->getRoleClass();
+        $repo = $this->em->getRepository(Role::class);
+
+        foreach ($data as $name => $params) {
+            $poids = $params['poids'] ?? 0;
+            $description = $params['description'] ?? '';
+
+            $role = $repo->findOneBy(['role' => $name]);
+            if ($role === null) {
+                $role = new $roleClass($name, $poids, $description);
+                $this->em->persist($role);
+                $report->created[] = $name;
+            } else {
+                $changed = false;
+                if ($role->getPoids() !== $poids) {
+                    $role->setPoids($poids);
+                    $changed = true;
+                }
+                if ($role->getDescription() !== $description) {
+                    $role->setDescription($description);
+                    $changed = true;
+                }
+                if ($parent !== null && ($role->getParent()?->getRole() !== $parent->getRole())) {
+                    $role->setParent($parent);
+                    $changed = true;
+                }
+                if ($changed) {
+                    $report->updated[] = $name;
+                } else {
+                    $report->unchanged[] = $name;
+                }
+            }
+
+            if ($parent !== null && $role->getParent() === null) {
+                // First-insert path: setParent here so child recursion sees the right anchor.
+                $role->setParent($parent);
+            }
+
+            if (!empty($params['children'])) {
+                $this->syncTree($params['children'], $role, $report);
+            }
+        }
+    }
+
+    /**
+     * Collapse duplicate role rows that share the same `role` name. For each
+     * such name the row with the smallest id wins; every foreign-key pointer
+     * (bsuser_role, fonction_role, autorisation_role, netbs_secure_roles.parent_id)
+     * to a non-canonical row is redirected to the canonical row, then the
+     * non-canonical rows are deleted.
+     *
+     * Returns the number of rows removed. Always safe to run — does nothing
+     * on a DB that already has no duplicates.
+     */
+    private function dedupeRoleRowsByName(): int
+    {
+        $conn = $this->em->getConnection();
+
+        // 1. Redirect bsuser_role pointers (INSERT IGNORE + DELETE to avoid PK collisions).
+        foreach (['bsuser_role' => 'bsuser_id', 'fonction_role' => 'fonction_id', 'autorisation_role' => 'autorisation_id'] as $table => $subjectCol) {
+            $conn->executeStatement("
+                INSERT IGNORE INTO $table ($subjectCol, role_id)
+                SELECT j.$subjectCol, k.keeper_id
+                FROM $table j
+                JOIN netbs_secure_roles dup ON dup.id = j.role_id
+                JOIN (SELECT role, MIN(id) AS keeper_id FROM netbs_secure_roles GROUP BY role) k
+                     ON k.role = dup.role
+                WHERE dup.id <> k.keeper_id
+            ");
+            $conn->executeStatement("
+                DELETE j FROM $table j
+                JOIN netbs_secure_roles dup ON dup.id = j.role_id
+                JOIN (SELECT role, MIN(id) AS keeper_id FROM netbs_secure_roles GROUP BY role) k
+                     ON k.role = dup.role
+                WHERE dup.id <> k.keeper_id
+            ");
+        }
+
+        // 2. Redirect parent_id pointers off duplicates so the tree stays intact.
+        $conn->executeStatement("
+            UPDATE netbs_secure_roles r
+            JOIN netbs_secure_roles dup ON dup.id = r.parent_id
+            JOIN (SELECT role, MIN(id) AS keeper_id FROM netbs_secure_roles GROUP BY role) k
+                 ON k.role = dup.role
+            SET r.parent_id = k.keeper_id
+            WHERE dup.id <> k.keeper_id
+        ");
+
+        // 3. Delete the duplicate rows.
+        $deleted = (int) $conn->executeStatement("
+            DELETE r FROM netbs_secure_roles r
+            JOIN (SELECT role, MIN(id) AS keeper_id FROM netbs_secure_roles GROUP BY role) k
+                 ON k.role = r.role
+            WHERE r.id <> k.keeper_id
+        ");
+
+        // Tell Doctrine its in-memory Role identity map may be stale.
+        $this->em->clear(Role::class);
+
+        return $deleted;
+    }
+}

--- a/netBS/core/SecureBundle/Service/SystemRoleTreeSource.php
+++ b/netBS/core/SecureBundle/Service/SystemRoleTreeSource.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace NetBS\SecureBundle\Service;
+
+/**
+ * Source for the minimal system role tree (ROLE_ADMIN → ROLE_USER) defined
+ * by SecureBundle. Runs first so other bundles can graft onto ROLE_ADMIN.
+ */
+final class SystemRoleTreeSource implements RoleTreeSourceInterface
+{
+    public function getYamlPath(): string
+    {
+        return __DIR__ . '/../Resources/security/system_roles.yml';
+    }
+
+    public function getRootParent(): ?string
+    {
+        return null;
+    }
+
+    public function getOrder(): int
+    {
+        return 1;
+    }
+}

--- a/src/Resources/structure/roles.yml
+++ b/src/Resources/structure/roles.yml
@@ -1,4 +1,7 @@
 roles:
+    ROLE_APMBS:
+        description: "Membre de l'APMBS"
+        poids: 900
     ROLE_COMMANDANT:
         description: "Role du commandant"
         poids: 1000

--- a/src/Resources/structure/roles.yml
+++ b/src/Resources/structure/roles.yml
@@ -1,102 +1,102 @@
 roles:
     ROLE_APMBS:
-        description: "Membre de l'APMBS (Association des Parents et Anciens). Donne le plein CRUD sur le module de réservation des cabanes : Cabane, APMBSReservation, CabaneTimePeriod, Intendant, ReservationLog (voir APMBSVoter). Active le menu 'APMBS' en sidebar. N'a aucun effet sur les données du fichier des membres."
+        description: "Gestion des réservations de cabanes."
         poids: 900
     ROLE_COMMANDANT:
-        description: "Chef de l'organisation. Racine de la hiérarchie organisationnelle : enfant de ce rôle hérite tous ses descendants (QM + branches + clans + camps). Reçoit automatiquement ROLE_SG par grafting de FichierBundle — donc accès global au fichier. Pas de capacité métier directe au-delà de l'héritage."
+        description: "Accès complet au fichier."
         poids: 1000
         children:
             ROLE_QM:
-                description: "Quartier-maître. Coordonne l'administration interne (trésorerie, communication, formations, matériel, économat). Parent regroupant les rôles de fonction support — n'octroie aucune capacité métier directe, sert de chapeau hiérarchique."
+                description: "Accès complet au fichier."
                 poids: 990
                 children:
                     ROLE_MEMBRE_EDC:
-                        description: "Membre de l'Équipe de Coordination. Rôle de tagging hiérarchique — n'octroie aucune capacité métier directe."
+                        description: ""
                         poids: 980
                     ROLE_TRESORIER:
-                        description: "Trésorier. Donne le plein CRUD sur le module de facturation : Facture, Creance, Paiement, Rappel, FactureModel, Compte (voir FacturationVoter). Active le menu 'Cotisations' et affiche les factures sur les fiches membres."
+                        description: "Gestion des factures, paiements, rappels et cotisations."
                         poids: 980
                     ROLE_MAILING:
-                        description: "Gestionnaire des listes de diffusion. Donne le plein CRUD sur MailingList, MailingTarget, MailingListAlias (voir MailingListVoter). Active le menu 'Mailings'."
+                        description: "Gestion des listes de diffusion et de leurs membres."
                         poids: 980
                     ROLE_RESPONSABLE_COMM:
-                        description: "Responsable communication. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_RESPONSABLE_PUBLICATIONS."
+                        description: ""
                         poids: 980
                         children:
                             ROLE_RESPONSABLE_PUBLICATIONS:
                                 poids: 800
-                                description: "Responsable publications. Rôle de tagging — n'octroie aucune capacité métier directe."
+                                description: ""
                     ROLE_RESPONSABLE_FORMATION_EXTERNE:
-                        description: "Responsable formation externe. Rôle de tagging — n'octroie aucune capacité métier directe."
+                        description: ""
                         poids: 980
                     ROLE_RESPONSABLE_FORMATION_INTERNE:
-                        description: "Responsable formation interne. Rôle de tagging — n'octroie aucune capacité métier directe."
+                        description: ""
                         poids: 980
                     ROLE_RESPONSABLE_LOCAUX:
-                        description: "Responsable des locaux. Rôle de tagging — n'octroie aucune capacité métier directe."
+                        description: ""
                         poids: 980
                     ROLE_COACH:
-                        description: "Coach JS (Jeunesse + Sport). Rôle de tagging — n'octroie aucune capacité métier directe. Mêmes responsabilités que la formation externe côté association."
+                        description: ""
                         poids: 980
                     ROLE_CHEF_MAT:
-                        description: "Chef matériel. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_CHEF_MAT_ADJOINT."
+                        description: ""
                         poids: 800
                         children:
                             ROLE_CHEF_MAT_ADJOINT:
                                 poids: 700
-                                description: "Chef matériel adjoint. Rôle de tagging — n'octroie aucune capacité métier directe."
+                                description: ""
                     ROLE_CHEF_TENTES:
-                        description: "Chef tentes. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_CHEF_TENTES_ADJOINT."
+                        description: ""
                         poids: 800
                         children:
                             ROLE_CHEF_TENTES_ADJOINT:
                                 poids: 700
-                                description: "Chef tentes adjoint. Rôle de tagging — n'octroie aucune capacité métier directe."
+                                description: ""
                     ROLE_RESPONSABLE_ECONOMAT:
-                        description: "Responsable de l'économat. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_RESPONSABLE_ECONOMAT_ADJOINT."
+                        description: ""
                         poids: 800
                         children:
                             ROLE_RESPONSABLE_ECONOMAT_ADJOINT:
                                 poids: 700
-                                description: "Économat adjoint. Rôle de tagging — n'octroie aucune capacité métier directe."
+                                description: ""
             ROLE_CB:
-                description: "Chef de branche. Responsable d'une branche (Meute, Troupe, Clan, etc.). Rôle de tagging hiérarchique — les capacités d'accès aux membres de la branche viennent des autorisations/attributions sur les groupes correspondants, pas du rôle lui-même."
+                description: "Accès aux membres de la branche via les autorisations attachées à la fonction."
                 poids: 980
                 children:
                     ROLE_CB_ADJ:
-                        description: "Chef de branche adjoint. Rôle de tagging hiérarchique — pas de capacité métier directe."
+                        description: "Accès aux membres de la branche via les autorisations attachées à la fonction."
                         poids: 950
                         children:
                             ROLE_CHEF_MEUTE:
-                                description: "Chef de meute (louveteaux). Rôle de tagging — accès aux louveteaux via attributions/autorisations sur le groupe meute."
+                                description: "Accès aux louveteaux via les autorisations attachées à la fonction."
                                 poids: 300
                                 children:
                                     ROLE_CHEF_MEUTE_ADJOINT:
-                                        description: "Adjoint chef de meute. Rôle de tagging — pas de capacité métier directe."
+                                        description: "Accès aux louveteaux via les autorisations attachées à la fonction."
                                         poids: 250
 
 
             ROLE_CHEF_CLAN:
-                description: "Chef de clan (Routiers / Pionniers). Rôle de tagging — accès aux membres du clan via attributions/autorisations sur le groupe clan."
+                description: "Accès aux membres du clan via les autorisations attachées à la fonction."
                 poids: 650
                 children:
                     ROLE_MEMBRE_CLAN:
                         poids: 100
-                        description: "Membre du clan. Rôle de tagging — pas de capacité métier directe."
+                        description: ""
             ROLE_CHEF_EQUIPE:
-                description: "Chef d'équipe. Rôle de tagging — pas de capacité métier directe au-delà des autorisations explicites."
+                description: "Accès aux membres de l'équipe via les autorisations attachées à la fonction."
                 poids: 650
                 children:
                     ROLE_ADJOINT_CHEF_EQUIPE:
-                        description: "Adjoint chef d'équipe. Rôle de tagging — pas de capacité métier directe."
+                        description: "Accès aux membres de l'équipe via les autorisations attachées à la fonction."
                         poids: 500
             ROLE_CHEF_CE:
-                description: "Chef de camp d'été. Rôle de tagging — pas de capacité métier directe au-delà des autorisations explicites."
+                description: "Accès aux membres du camp via les autorisations attachées à la fonction."
                 poids: 300
                 children:
                     ROLE_ADJOINT_CHEF_CE:
-                        description: "Adjoint chef de camp d'été. Rôle de tagging — pas de capacité métier directe."
+                        description: "Accès aux membres du camp via les autorisations attachées à la fonction."
                         poids: 250
             ROLE_CHEF_SAINT_GEORGES:
-                description: "Chef de la Saint-Georges (cérémonie annuelle). Rôle de tagging — pas de capacité métier directe."
+                description: ""
                 poids: 300

--- a/src/Resources/structure/roles.yml
+++ b/src/Resources/structure/roles.yml
@@ -1,102 +1,102 @@
 roles:
     ROLE_APMBS:
-        description: "Membre de l'APMBS"
+        description: "Membre de l'APMBS (Association des Parents et Anciens). Donne le plein CRUD sur le module de réservation des cabanes : Cabane, APMBSReservation, CabaneTimePeriod, Intendant, ReservationLog (voir APMBSVoter). Active le menu 'APMBS' en sidebar. N'a aucun effet sur les données du fichier des membres."
         poids: 900
     ROLE_COMMANDANT:
-        description: "Role du commandant"
+        description: "Chef de l'organisation. Racine de la hiérarchie organisationnelle : enfant de ce rôle hérite tous ses descendants (QM + branches + clans + camps). Reçoit automatiquement ROLE_SG par grafting de FichierBundle — donc accès global au fichier. Pas de capacité métier directe au-delà de l'héritage."
         poids: 1000
         children:
             ROLE_QM:
-                description: "Role du QM"
+                description: "Quartier-maître. Coordonne l'administration interne (trésorerie, communication, formations, matériel, économat). Parent regroupant les rôles de fonction support — n'octroie aucune capacité métier directe, sert de chapeau hiérarchique."
                 poids: 990
                 children:
                     ROLE_MEMBRE_EDC:
-                        description: "membre de l'EDC"
+                        description: "Membre de l'Équipe de Coordination. Rôle de tagging hiérarchique — n'octroie aucune capacité métier directe."
                         poids: 980
                     ROLE_TRESORIER:
-                        description: "Trésorier"
+                        description: "Trésorier. Donne le plein CRUD sur le module de facturation : Facture, Creance, Paiement, Rappel, FactureModel, Compte (voir FacturationVoter). Active le menu 'Cotisations' et affiche les factures sur les fiches membres."
                         poids: 980
                     ROLE_MAILING:
-                        description: "Gestionnaire des listes de diffusion"
+                        description: "Gestionnaire des listes de diffusion. Donne le plein CRUD sur MailingList, MailingTarget, MailingListAlias (voir MailingListVoter). Active le menu 'Mailings'."
                         poids: 980
                     ROLE_RESPONSABLE_COMM:
-                        description: "Responsable communication"
+                        description: "Responsable communication. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_RESPONSABLE_PUBLICATIONS."
                         poids: 980
                         children:
                             ROLE_RESPONSABLE_PUBLICATIONS:
                                 poids: 800
-                                description: "Responsable publications"
+                                description: "Responsable publications. Rôle de tagging — n'octroie aucune capacité métier directe."
                     ROLE_RESPONSABLE_FORMATION_EXTERNE:
-                        description: "Responsable formation externe"
+                        description: "Responsable formation externe. Rôle de tagging — n'octroie aucune capacité métier directe."
                         poids: 980
                     ROLE_RESPONSABLE_FORMATION_INTERNE:
-                        description: "Responsable formation interne"
+                        description: "Responsable formation interne. Rôle de tagging — n'octroie aucune capacité métier directe."
                         poids: 980
                     ROLE_RESPONSABLE_LOCAUX:
-                        description: "Responsable des locaux"
+                        description: "Responsable des locaux. Rôle de tagging — n'octroie aucune capacité métier directe."
                         poids: 980
                     ROLE_COACH:
-                        description: "Responsable formation externe"
+                        description: "Coach JS (Jeunesse + Sport). Rôle de tagging — n'octroie aucune capacité métier directe. Mêmes responsabilités que la formation externe côté association."
                         poids: 980
                     ROLE_CHEF_MAT:
-                        description: "Chef mat'"
+                        description: "Chef matériel. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_CHEF_MAT_ADJOINT."
                         poids: 800
                         children:
                             ROLE_CHEF_MAT_ADJOINT:
                                 poids: 700
-                                description: "Chef mat' adjoint"
+                                description: "Chef matériel adjoint. Rôle de tagging — n'octroie aucune capacité métier directe."
                     ROLE_CHEF_TENTES:
-                        description: "Chef tentes"
+                        description: "Chef tentes. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_CHEF_TENTES_ADJOINT."
                         poids: 800
                         children:
                             ROLE_CHEF_TENTES_ADJOINT:
                                 poids: 700
-                                description: "Chef tentes adjoint"
+                                description: "Chef tentes adjoint. Rôle de tagging — n'octroie aucune capacité métier directe."
                     ROLE_RESPONSABLE_ECONOMAT:
-                        description: "Responsable de l'économat"
+                        description: "Responsable de l'économat. Rôle de tagging — n'octroie aucune capacité métier directe. Parent de ROLE_RESPONSABLE_ECONOMAT_ADJOINT."
                         poids: 800
                         children:
                             ROLE_RESPONSABLE_ECONOMAT_ADJOINT:
                                 poids: 700
-                                description: "Chef économat adjoint"
+                                description: "Économat adjoint. Rôle de tagging — n'octroie aucune capacité métier directe."
             ROLE_CB:
-                description: "Chef de branche"
+                description: "Chef de branche. Responsable d'une branche (Meute, Troupe, Clan, etc.). Rôle de tagging hiérarchique — les capacités d'accès aux membres de la branche viennent des autorisations/attributions sur les groupes correspondants, pas du rôle lui-même."
                 poids: 980
                 children:
                     ROLE_CB_ADJ:
-                        description: "Chef de branche adjoint"
+                        description: "Chef de branche adjoint. Rôle de tagging hiérarchique — pas de capacité métier directe."
                         poids: 950
                         children:
                             ROLE_CHEF_MEUTE:
-                                description: "Chef de meute"
+                                description: "Chef de meute (louveteaux). Rôle de tagging — accès aux louveteaux via attributions/autorisations sur le groupe meute."
                                 poids: 300
                                 children:
                                     ROLE_CHEF_MEUTE_ADJOINT:
-                                        description: "adjoint chef de meute"
+                                        description: "Adjoint chef de meute. Rôle de tagging — pas de capacité métier directe."
                                         poids: 250
 
 
             ROLE_CHEF_CLAN:
-                description: "Chef de clan"
+                description: "Chef de clan (Routiers / Pionniers). Rôle de tagging — accès aux membres du clan via attributions/autorisations sur le groupe clan."
                 poids: 650
                 children:
                     ROLE_MEMBRE_CLAN:
                         poids: 100
-                        description: "Membre d'un clan"
+                        description: "Membre du clan. Rôle de tagging — pas de capacité métier directe."
             ROLE_CHEF_EQUIPE:
-                description: "Chef d'équipe"
+                description: "Chef d'équipe. Rôle de tagging — pas de capacité métier directe au-delà des autorisations explicites."
                 poids: 650
                 children:
                     ROLE_ADJOINT_CHEF_EQUIPE:
-                        description: "Adjoint chef d'équipe"
+                        description: "Adjoint chef d'équipe. Rôle de tagging — pas de capacité métier directe."
                         poids: 500
             ROLE_CHEF_CE:
-                description: "Chef de camp d'été"
+                description: "Chef de camp d'été. Rôle de tagging — pas de capacité métier directe au-delà des autorisations explicites."
                 poids: 300
                 children:
                     ROLE_ADJOINT_CHEF_CE:
-                        description: "Adjoint chef de camp d'été"
+                        description: "Adjoint chef de camp d'été. Rôle de tagging — pas de capacité métier directe."
                         poids: 250
             ROLE_CHEF_SAINT_GEORGES:
-                description: "Chef de la St-Georges"
+                description: "Chef de la Saint-Georges (cérémonie annuelle). Rôle de tagging — pas de capacité métier directe."
                 poids: 300

--- a/src/Service/AppRoleTreeSource.php
+++ b/src/Service/AppRoleTreeSource.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Service;
+
+use NetBS\SecureBundle\Service\RoleTreeSourceInterface;
+
+/**
+ * App-specific role subtree (`ROLE_QM`, `ROLE_CB`, `ROLE_CHEF_CLAN`, …)
+ * grafted under `ROLE_COMMANDANT` (which is itself created by
+ * FichierBundle's source).
+ *
+ * Runs last (order 500) so both system and Fichier sources have already
+ * created ROLE_COMMANDANT before this graft point is looked up.
+ *
+ * Note: the YAML re-declares ROLE_COMMANDANT at its top level so the
+ * structure file is self-describing. The syncer's upsert collapses that
+ * onto the same canonical ROLE_COMMANDANT row created earlier.
+ */
+final class AppRoleTreeSource implements RoleTreeSourceInterface
+{
+    public function getYamlPath(): string
+    {
+        return __DIR__ . '/../Resources/structure/roles.yml';
+    }
+
+    public function getRootParent(): ?string
+    {
+        return 'ROLE_ADMIN';
+    }
+
+    public function getOrder(): int
+    {
+        return 500;
+    }
+}

--- a/tests/SecureBundle/Service/AccessAuditServiceTest.php
+++ b/tests/SecureBundle/Service/AccessAuditServiceTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\SecureBundle\Service;
+
+use App\Entity\BSGroupe;
+use App\Entity\BSUser;
+use NetBS\FichierBundle\Entity\Attribution;
+use NetBS\FichierBundle\Entity\Fonction;
+use NetBS\FichierBundle\Entity\Membre;
+use NetBS\SecureBundle\Audit\Provenance;
+use NetBS\SecureBundle\Entity\Autorisation;
+use NetBS\SecureBundle\Entity\Role;
+use NetBS\SecureBundle\Service\AccessAuditService;
+use PHPUnit\Framework\TestCase;
+
+class AccessAuditServiceTest extends TestCase
+{
+    public function test_audits_user_combining_all_three_sources(): void
+    {
+        // Roles
+        $roleAdmin    = (new Role())->setRole('ROLE_ADMIN');
+        $roleTresorier = (new Role())->setRole('ROLE_TRESORIER');
+        $roleApmbs    = (new Role())->setRole('ROLE_APMBS');
+
+        // Groupes
+        $groupeA = new BSGroupe();
+        $groupeA->setNom('A');
+        $groupeB = new BSGroupe();
+        $groupeB->setNom('B');
+
+        // Fonction with TRESORIER role
+        $fonction = new Fonction();
+        $fonction->setNom('Trésorier');
+        $fonction->setAbbreviation('Tr');
+        $fonction->addRole($roleTresorier);
+
+        // Membre
+        $membre = new Membre();
+
+        // Attribution: active (1 year ago → 1 year in future)
+        $attribution = new Attribution();
+        $attribution->setFonction($fonction);
+        $attribution->setGroupe($groupeA);
+        $attribution->setDateDebut((new \DateTime())->modify('-1 year'));
+        $attribution->setDateFin((new \DateTime())->modify('+1 year'));
+        $membre->addAttribution($attribution);
+
+        // BSUser with direct role
+        $user = new BSUser();
+        $user->setUsername('testuser');
+        $user->setMembre($membre);
+        $user->addRole($roleAdmin);
+
+        // Autorisation on groupeB with APMBS role
+        $autorisation = new Autorisation();
+        $autorisation->setUser($user);
+        $autorisation->setGroupe($groupeB);
+        $autorisation->getRoles()->add($roleApmbs);
+        $user->addAutorisation($autorisation);
+
+        // Act
+        $report = (new AccessAuditService())->auditUser($user);
+
+        // Assert: 3 grants total
+        $this->assertCount(3, $report->grants);
+
+        // Index by provenance value
+        $byProvenance = [];
+        foreach ($report->grants as $grant) {
+            $byProvenance[$grant->provenance->value] = $grant;
+        }
+
+        $this->assertArrayHasKey(Provenance::DIRECT_ROLE->value, $byProvenance);
+        $this->assertArrayHasKey(Provenance::FONCTION_ROLE->value, $byProvenance);
+        $this->assertArrayHasKey(Provenance::AUTORISATION->value, $byProvenance);
+
+        // DIRECT_ROLE has ROLE_ADMIN
+        $directGrant = $byProvenance[Provenance::DIRECT_ROLE->value];
+        $directRoleNames = array_map(fn($r) => $r->getRole(), $directGrant->roles);
+        $this->assertContains('ROLE_ADMIN', $directRoleNames);
+
+        // FONCTION_ROLE scope is groupeA
+        $fonctionGrant = $byProvenance[Provenance::FONCTION_ROLE->value];
+        $this->assertSame($groupeA, $fonctionGrant->scope);
+
+        // AUTORISATION scope is groupeB
+        $autorisationGrant = $byProvenance[Provenance::AUTORISATION->value];
+        $this->assertSame($groupeB, $autorisationGrant->scope);
+    }
+
+    public function test_audits_user_with_fonction_role_labels_source_fonction_and_scope(): void
+    {
+        $roleX = (new Role())->setRole('ROLE_X');
+
+        $groupe = new BSGroupe();
+        $groupe->setNom('TestGroupe');
+
+        $fonction = new Fonction();
+        $fonction->setNom('Trésorier');
+        $fonction->setAbbreviation('Tr');
+        $fonction->addRole($roleX);
+
+        $membre = new Membre();
+
+        $attribution = new Attribution();
+        $attribution->setFonction($fonction);
+        $attribution->setGroupe($groupe);
+        $attribution->setDateDebut((new \DateTime())->modify('-1 year'));
+        $attribution->setDateFin((new \DateTime())->modify('+1 year'));
+        $membre->addAttribution($attribution);
+
+        $user = new BSUser();
+        $user->setUsername('fonctionuser');
+        $user->setMembre($membre);
+        // No direct roles, no autorisations
+
+        $report = (new AccessAuditService())->auditUser($user);
+
+        $this->assertCount(1, $report->grants);
+
+        $grant = $report->grants[0];
+        $this->assertSame(Provenance::FONCTION_ROLE, $grant->provenance);
+        $this->assertSame($fonction, $grant->sourceFonction);
+        $this->assertSame($groupe, $grant->scope);
+    }
+
+    public function test_expands_role_tree_recursively_within_a_grant(): void
+    {
+        $parent = (new Role())->setRole('ROLE_PARENT');
+        $child  = (new Role())->setRole('ROLE_CHILD');
+
+        // addChild is the confirmed method in BaseRole::addChild
+        $parent->addChild($child);
+
+        $user = new BSUser();
+        $user->setUsername('recursiveuser');
+        $user->addRole($parent);
+
+        $report = (new AccessAuditService())->auditUser($user);
+
+        $this->assertCount(1, $report->grants);
+        $grant = $report->grants[0];
+
+        $roleNames = array_map(fn($r) => $r->getRole(), $grant->roles);
+        $this->assertContains('ROLE_PARENT', $roleNames);
+        $this->assertContains('ROLE_CHILD', $roleNames);
+    }
+}

--- a/tests/SecureBundle/Service/AccessAuditServiceTest.php
+++ b/tests/SecureBundle/Service/AccessAuditServiceTest.php
@@ -201,13 +201,23 @@ class AccessAuditServiceTest extends TestCase
     {
         $service = $this->makeService();
 
+        $flatten = static function (array $groupes, array $byName): array {
+            $out = [];
+            foreach ($groupes as $g) {
+                foreach ($byName[$g->getNom()] ?? [] as $item) {
+                    $out[] = $item;
+                }
+            }
+            return $out;
+        };
+
         $autoRef = new \ReflectionProperty(AccessAuditService::class, 'autorisationFinder');
         $autoRef->setAccessible(true);
-        $autoRef->setValue($service, fn(\NetBS\FichierBundle\Mapping\BaseGroupe $g) => $autorisations[$g->getNom()] ?? []);
+        $autoRef->setValue($service, fn(array $groupes) => $flatten($groupes, $autorisations));
 
         $attrRef = new \ReflectionProperty(AccessAuditService::class, 'attributionFinder');
         $attrRef->setAccessible(true);
-        $attrRef->setValue($service, fn(\NetBS\FichierBundle\Mapping\BaseGroupe $g) => $attributions[$g->getNom()] ?? []);
+        $attrRef->setValue($service, fn(array $groupes) => $flatten($groupes, $attributions));
 
         return $service;
     }

--- a/tests/SecureBundle/Service/AccessAuditServiceTest.php
+++ b/tests/SecureBundle/Service/AccessAuditServiceTest.php
@@ -61,7 +61,7 @@ class AccessAuditServiceTest extends TestCase
         $user->addAutorisation($autorisation);
 
         // Act
-        $report = (new AccessAuditService())->auditUser($user);
+        $report = $this->makeService()->auditUser($user);
 
         // Assert: 3 grants total
         $this->assertCount(3, $report->grants);
@@ -116,7 +116,7 @@ class AccessAuditServiceTest extends TestCase
         $user->setMembre($membre);
         // No direct roles, no autorisations
 
-        $report = (new AccessAuditService())->auditUser($user);
+        $report = $this->makeService()->auditUser($user);
 
         $this->assertCount(1, $report->grants);
 
@@ -138,7 +138,7 @@ class AccessAuditServiceTest extends TestCase
         $user->setUsername('recursiveuser');
         $user->addRole($parent);
 
-        $report = (new AccessAuditService())->auditUser($user);
+        $report = $this->makeService()->auditUser($user);
 
         $this->assertCount(1, $report->grants);
         $grant = $report->grants[0];
@@ -146,5 +146,81 @@ class AccessAuditServiceTest extends TestCase
         $roleNames = array_map(fn($r) => $r->getRole(), $grant->roles);
         $this->assertContains('ROLE_PARENT', $roleNames);
         $this->assertContains('ROLE_CHILD', $roleNames);
+    }
+
+    public function test_audits_scope_groupe_walks_parent_chain(): void
+    {
+        $root = $this->makeGroupe('root');
+        $mid  = $this->makeGroupe('mid');
+        $leaf = $this->makeGroupe('leaf');
+        $mid->setParent($root);
+        $leaf->setParent($mid);
+
+        $userOnRoot = new BSUser();
+        $userOnRoot->setUsername('on_root');
+        $autoRoot = new Autorisation();
+        $autoRoot->setUser($userOnRoot);
+        $autoRoot->setGroupe($root);
+        $autoRoot->getRoles()->add($this->makeRole('ROLE_X'));
+        $userOnRoot->addAutorisation($autoRoot);
+
+        $userOnLeaf = new BSUser();
+        $userOnLeaf->setUsername('on_leaf');
+        $autoLeaf = new Autorisation();
+        $autoLeaf->setUser($userOnLeaf);
+        $autoLeaf->setGroupe($leaf);
+        $autoLeaf->getRoles()->add($this->makeRole('ROLE_Y'));
+        $userOnLeaf->addAutorisation($autoLeaf);
+
+        $service = $this->makeServiceWithFinders(
+            autorisations: [
+                $root->getNom() => [$autoRoot],
+                $mid->getNom()  => [],
+                $leaf->getNom() => [$autoLeaf],
+            ],
+            attributions: [],
+        );
+
+        $report = $service->auditScope($leaf);
+
+        $usernames = array_map(fn($entry) => $entry->user->getUsername(), $report->entries);
+        sort($usernames);
+        $this->assertSame(['on_leaf', 'on_root'], $usernames);
+    }
+
+    private function makeService(): AccessAuditService
+    {
+        return new AccessAuditService(
+            $this->createMock(\Doctrine\ORM\EntityManagerInterface::class),
+            $this->createMock(\NetBS\SecureBundle\Service\SecureConfig::class),
+            $this->createMock(\NetBS\FichierBundle\Service\FichierConfig::class),
+        );
+    }
+
+    private function makeServiceWithFinders(array $autorisations, array $attributions): AccessAuditService
+    {
+        $service = $this->makeService();
+
+        $autoRef = new \ReflectionProperty(AccessAuditService::class, 'autorisationFinder');
+        $autoRef->setAccessible(true);
+        $autoRef->setValue($service, fn(\NetBS\FichierBundle\Mapping\BaseGroupe $g) => $autorisations[$g->getNom()] ?? []);
+
+        $attrRef = new \ReflectionProperty(AccessAuditService::class, 'attributionFinder');
+        $attrRef->setAccessible(true);
+        $attrRef->setValue($service, fn(\NetBS\FichierBundle\Mapping\BaseGroupe $g) => $attributions[$g->getNom()] ?? []);
+
+        return $service;
+    }
+
+    private function makeGroupe(string $nom): BSGroupe
+    {
+        $g = new BSGroupe();
+        $g->setNom($nom);
+        return $g;
+    }
+
+    private function makeRole(string $role): Role
+    {
+        return (new Role())->setRole($role);
     }
 }


### PR DESCRIPTION
## Summary

- Extracts the role-syncer infrastructure from `feat/oidc-identity-provider` (commit 7d1c74f) so it can ship without the OIDC/Hydra stack.
- Adds `RoleTreeSyncer` + `RoleTreeSourceInterface` (tagged iterator) with three sources: `SystemRoleTreeSource`, `FichierRoleTreeSource`, `AppRoleTreeSource`. Replaces ad-hoc role insertion in `LoadRolesData` fixtures with a declarative YAML source-of-truth flow.
- Exposes `netbs:roles:sync` (reconcile) and `netbs:debug:user-roles` (inspect) commands.
- Trims `LoadRolesData` (Fichier + Secure) and updates `roles.yml` / `system_roles.yml` / `src/Resources/structure/roles.yml` to the schema the syncer expects.

No OIDC/Hydra coupling — verified by `php bin/console cache:clear` (clean DI compile) and command registration.

## Test plan

- [ ] `php bin/console cache:clear` succeeds
- [ ] `php bin/console netbs:roles:sync` reconciles the tree on a fresh DB
- [ ] `php bin/console netbs:roles:sync` is idempotent on a second run
- [ ] `php bin/console netbs:debug:user-roles <user>` lists effective roles
- [ ] Existing app login + role-gated routes still work after sync