### PR TITLE
Harden login form: password-manager support, CSRF, and behaviour tests

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -36,6 +36,7 @@ security:
                 login_path: netbs.secure.login.login
                 check_path: netbs.secure.login.login
                 default_target_path: netbs.core.home.dashboard
+                enable_csrf: true
             remember_me:
                 secret: '%kernel.secret%'
                 lifetime: 604800

--- a/netBS/core/SecureBundle/Resources/views/login/login.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/login/login.html.twig
@@ -42,14 +42,22 @@
                 <form action="{{ path('netbs.secure.login.login') }}" method="POST" data-turbo="false">
 
                     <div class="form-group">
+                        <label for="username" class="form-label visually-hidden">Nom d'utilisateur</label>
                         <div class="input-group">
-                            <input id="username" name="_username" type="text" placeholder="Nom d'utilisateur" class="form-control">
+                            <input id="username" name="_username" type="text"
+                                   value="{{ last_username }}"
+                                   autocomplete="username" autocapitalize="none" autocorrect="off"
+                                   spellcheck="false" required autofocus
+                                   placeholder="Nom d'utilisateur" class="form-control">
                         </div>
                     </div>
 
                     <div class="form-group">
+                        <label for="password" class="form-label visually-hidden">Mot de passe</label>
                         <div class="input-group">
-                            <input id="password" name="_password" type="password" placeholder="Mot de passe" class="form-control">
+                            <input id="password" name="_password" type="password"
+                                   autocomplete="current-password" required
+                                   placeholder="Mot de passe" class="form-control">
                         </div>
                     </div>
 
@@ -67,7 +75,7 @@
                             <a href="{{ path('netbs.secure.password_reset.request') }}">Mot de passe oublié&nbsp;?</a>
                         </div>
                     </div>
-                    <button data-bs-dismiss="modal" class="btn btn-primary w-100">Connexion</button>
+                    <button type="submit" class="btn btn-primary w-100">Connexion</button>
 
                     {% if error %}
                         <p class="text-danger text-center">{{ error.messageKey|trans(error.messageData, 'security') }}</p>

--- a/netBS/core/SecureBundle/Resources/views/login/login.html.twig
+++ b/netBS/core/SecureBundle/Resources/views/login/login.html.twig
@@ -41,6 +41,8 @@
             <div class="card-body">
                 <form action="{{ path('netbs.secure.login.login') }}" method="POST" data-turbo="false">
 
+                    <input type="hidden" name="_csrf_token" value="{{ csrf_token('authenticate') }}">
+
                     <div class="form-group">
                         <label for="username" class="form-label visually-hidden">Nom d'utilisateur</label>
                         <div class="input-group">

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -74,4 +74,25 @@ class LoginControllerTest extends WebTestCase
             'the login form must re-populate the username after a failed attempt'
         );
     }
+
+    public function test_login_without_a_csrf_token_is_rejected(): void
+    {
+        $client = static::createClient();
+        $this->persistUser($client, 'login-test-csrf', 'login-csrf@example.test', self::PASSWORD, ['ROLE_USER']);
+
+        // Raw POST that bypasses the rendered form, so no _csrf_token is sent.
+        // With CSRF enforced these otherwise-valid credentials must be refused.
+        $client->request('POST', self::LOGIN_URL, [
+            '_username' => 'login-test-csrf',
+            '_password' => self::PASSWORD,
+        ]);
+
+        $this->assertResponseRedirects();
+        $client->followRedirect();
+        $this->assertStringContainsString(
+            '/secure/login',
+            $client->getRequest()->getUri(),
+            'a login submitted without a valid CSRF token must be rejected'
+        );
+    }
 }

--- a/tests/Controller/LoginControllerTest.php
+++ b/tests/Controller/LoginControllerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Tests\Controller;
+
+use App\Tests\Support\UserFactoryTrait;
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+
+/**
+ * Covers the main netBS login screen: the markup contract that lets password
+ * managers and browser autofill recognise the form, and the authentication
+ * behaviour the template is wired to (successful login, and a failed login
+ * showing an error while re-populating the username).
+ */
+class LoginControllerTest extends WebTestCase
+{
+    use UserFactoryTrait;
+
+    private const LOGIN_URL = '/netBS/secure/login';
+    private const PASSWORD = 'C0rrect-horse-battery';
+
+    /**
+     * The markup contract password managers and autofill rely on: an identified
+     * username/password pair and an explicit submit button.
+     */
+    public function test_login_form_markup_supports_password_managers(): void
+    {
+        $client = static::createClient();
+        $client->request('GET', self::LOGIN_URL);
+
+        $this->assertResponseIsSuccessful();
+        $this->assertSelectorExists('input[name="_username"][autocomplete="username"]');
+        $this->assertSelectorExists('input[name="_password"][autocomplete="current-password"]');
+        $this->assertSelectorExists('label[for="username"]');
+        $this->assertSelectorExists('label[for="password"]');
+        $this->assertSelectorExists('form button[type="submit"]');
+    }
+
+    public function test_valid_credentials_authenticate_and_redirect_off_the_login_page(): void
+    {
+        $client = static::createClient();
+        $this->persistUser($client, 'login-test-ok', 'login-ok@example.test', self::PASSWORD, ['ROLE_USER']);
+
+        $crawler = $client->request('GET', self::LOGIN_URL);
+        $form = $crawler->selectButton('Connexion')->form();
+        $form['_username'] = 'login-test-ok';
+        $form['_password'] = self::PASSWORD;
+        $client->submit($form);
+
+        $this->assertResponseRedirects();
+        $this->assertStringNotContainsString(
+            '/secure/login',
+            (string) $client->getResponse()->headers->get('Location'),
+            'a successful login must not bounce back to the login page'
+        );
+    }
+
+    public function test_failed_login_shows_an_error_and_repopulates_the_username(): void
+    {
+        $client = static::createClient();
+
+        $crawler = $client->request('GET', self::LOGIN_URL);
+        $form = $crawler->selectButton('Connexion')->form();
+        $form['_username'] = 'wrong-user';
+        $form['_password'] = 'definitely-the-wrong-password';
+        $client->submit($form);
+
+        $this->assertResponseRedirects();
+        $crawler = $client->followRedirect();
+        $this->assertStringContainsString('/secure/login', $client->getRequest()->getUri());
+        $this->assertSelectorExists('.text-danger');
+        $this->assertSame(
+            'wrong-user',
+            $crawler->filter('input[name="_username"]')->attr('value'),
+            'the login form must re-populate the username after a failed attempt'
+        );
+    }
+}


### PR DESCRIPTION
## Why

The main netBS login screen used placeholder-only fields with **no `autocomplete` hints**, so password managers (Proton Pass especially) and browser autofill couldn't reliably recognise the form or offer to save/fill credentials. The reset/change-password forms already got this treatment; the login screen never did. It also accepted credential POSTs with **no CSRF token**.

## Form changes (`login.html.twig`)

- `autocomplete="username"` / `autocomplete="current-password"` — the primary signal managers use to bind to the right fields
- real `<label for>` on both inputs (`visually-hidden` to keep the card's clean look) — placeholders aren't accessible names
- pre-fill the username from `last_username` (already passed by `LoginController` but previously unused) so a failed attempt keeps the typed name
- `required` + mobile hygiene (`autocapitalize="none"`, `autocorrect="off"`, `spellcheck="false"`, `autofocus`)
- removed stray `data-bs-dismiss="modal"` (copy-paste cruft — this is a full page, not a modal) and made the submit button an explicit `type="submit"`

`data-turbo="false"` on the form was already correct and is kept — it forces a native submit so managers can observe the post-login navigation and prompt to save.

## CSRF protection

- `enable_csrf: true` on the `form_login` firewall (`security.yaml`)
- hidden `_csrf_token` field rendered with `csrf_token('authenticate')` in the form

`symfony/security-csrf` is already installed and `framework.csrf_protection` is already on, so this is config + markup only — no new dependency. Existing sessions are unaffected; new logins require the token the form now renders.

## Tests (`tests/Controller/LoginControllerTest.php`)

Scoped to what this change touches — 4 tests:

- **markup contract**: username/password advertise the right autocomplete, both have associated labels, and the submit button is an explicit submit
- **valid credentials** authenticate and redirect off the login page (also guards the `_username`/`_password` field wiring and that the rendered CSRF token validates)
- a **failed login** shows an error and re-populates the username (guards the new `last_username` pre-fill)
- a **login without a CSRF token is rejected** and bounced back to the login page (guards CSRF enforcement)

Remember-me ("Se souvenir") is unchanged framework/config behaviour, so it's intentionally left uncovered here.

`43 tests / 115 assertions` green locally (full suite, PHP 8.3 / MariaDB 11 — same as CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
